### PR TITLE
Feat/api sucursales

### DIFF
--- a/src/app/(dashboard)/branches/BranchForm.tsx
+++ b/src/app/(dashboard)/branches/BranchForm.tsx
@@ -40,8 +40,8 @@ export default function BranchFrom({ onClose }: { onClose: () => void }) {
     longitud: "",
     gerenteResponsable: "",
     capacidadMiembros: "",
-    horarios: {}, // objeto con días de la semana
-    metodosPago: [], // array de strings
+    horarios: {},
+    metodosPago: [],
   });
 
   const steps = [
@@ -93,7 +93,9 @@ export default function BranchFrom({ onClose }: { onClose: () => void }) {
   };
 
   const handleNext = () => {
-    if (!validateStep()) {return;}
+    if (!validateStep()) {
+      return;
+    }
     if (currentStep < steps.length) {
       setCurrentStep(currentStep + 1);
     }
@@ -110,7 +112,7 @@ export default function BranchFrom({ onClose }: { onClose: () => void }) {
 
     console.log("Datos del formulario:", result.data);
     alert("Sucursal Creada");
-    onClose(); // cerrar modal si todo está bien
+    onClose();
   };
 
   const handleBack = () => {

--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -92,15 +92,15 @@ export default function BranchesTable({
       accessor: "status",
       filterType: "select",
       filterOptions: [
-        { label: "Activa", value: "active" },
-        { label: "Inactiva", value: "inactive" },
-        { label: "En mantenimiento", value: "maintenance" },
+        { label: "Activa", value: "Active" },
+        { label: "Inactiva", value: "Inactive" },
+        { label: "En mantenimiento", value: "Maintenance" },
       ],
       render: (value) => {
         const statusConfig = {
-          active: { text: "Activa", color: "text-green-700 border-green-300" },
-          inactive: { text: "Inactiva", color: "text-red-700 border-red-300" },
-          maintenance: {
+          Active: { text: "Activa", color: "text-green-700 border-green-300" },
+          Inactive: { text: "Inactiva", color: "text-red-700 border-red-300" },
+          Maintenance: {
             text: "En mantenimiento",
             color: "text-yellow-700 border-yellow-300",
           },

--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -14,12 +14,16 @@ import { PaymentMethod } from "@/types/paymentMethod";
 import { BranchesTableRow } from "@/services/branches";
 import { PaymentMethodUI } from "./page";
 
+export type FilterChangeHandler = (
+  key: string,
+  value: string | undefined,
+) => void;
+
 interface BranchesTableProps {
   data: BranchesTableRow[];
   isLoading: boolean;
   page: number;
   pageSize: number;
-  totalCount: number;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number) => void;
   allInstructors: Instructor[];
@@ -29,7 +33,11 @@ interface BranchesTableProps {
   allServices: Service[];
   allEquipment: Equipment[];
   allPaymentMethods: PaymentMethodUI[];
+  totalPages: number;
+  onFilterChange: FilterChangeHandler;
+  filterValues: Record<string, string | undefined>;
 }
+
 export default function BranchesTable({
   data,
   isLoading,
@@ -41,9 +49,11 @@ export default function BranchesTable({
   allPaymentMethods,
   page,
   pageSize,
-  totalCount,
+  totalPages,
   onPageChange,
   onPageSizeChange,
+  onFilterChange,
+  filterValues,
 }: BranchesTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedBranch, setSelectedBranch] = useState<BranchesTableRow | null>(
@@ -75,17 +85,11 @@ export default function BranchesTable({
   const columns: Column<BranchesTableRow>[] = [
     { header: "ID", accessor: "id" },
     { header: "Nombre", accessor: "name", filterType: "text" },
-    { header: "RIF", accessor: "taxId", filterType: "text" },
+    { header: "RIF", accessor: "taxId" },
     { header: "Administrador", accessor: "administrator" },
     {
       header: "País",
       accessor: "country",
-      filterType: "select",
-      filterOptions: [
-        { label: "Venezuela", value: "Venezuela" },
-        { label: "Colombia", value: "Colombia" },
-        { label: "Perú", value: "Perú" },
-      ],
     },
     {
       header: "Status",
@@ -128,6 +132,9 @@ export default function BranchesTable({
         onPageChange={onPageChange}
         onPageSizeChange={onPageSizeChange}
         enableFilters
+        totalPages={totalPages}
+        onFilterChange={onFilterChange}
+        filterValues={filterValues}
         actions={(row) => (
           <div className="flex items-center justify-center gap-2">
             <Button

--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -6,25 +6,30 @@ import EyeIcon from "@heroicons/react/24/outline/EyeIcon";
 import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
 import { useState } from "react";
 import BranchDetailsModal from "@/components/BranchDetailsModal";
-import { Branches } from "@/types/branches";
 import { Instructor } from "@/types/instructor";
 import { City, Country, State } from "@/types/location";
 import { Service } from "@/types/service";
 import { Equipment } from "@/types/equipment";
 import { PaymentMethod } from "@/types/paymentMethod";
+import { BranchesTableRow } from "@/services/branches";
+import { PaymentMethodUI } from "./page";
 
 interface BranchesTableProps {
-  data: Branches[];
+  data: BranchesTableRow[];
   isLoading: boolean;
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
   allInstructors: Instructor[];
   allCities: City[];
   allStates: State[];
+  //allCountries: Country[];
   allServices: Service[];
   allEquipment: Equipment[];
-  allPaymentMethods: PaymentMethod[];
-  allCountries: Country[];
+  allPaymentMethods: PaymentMethodUI[];
 }
-
 export default function BranchesTable({
   data,
   isLoading,
@@ -34,24 +39,29 @@ export default function BranchesTable({
   allServices,
   allEquipment,
   allPaymentMethods,
-  allCountries,
+  page,
+  pageSize,
+  totalCount,
+  onPageChange,
+  onPageSizeChange,
 }: BranchesTableProps) {
-  const [page, setPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedBranch, setSelectedBranch] = useState<Branches | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<BranchesTableRow | null>(
+    null,
+  );
   const [modalMode, setModalMode] = useState<"view" | "edit">("view");
 
   if (isLoading) {
     return <p className="text-center p-4">Cargando sucursales...</p>;
   }
 
-  const handleViewDetails = (branch: Branches) => {
+  const handleViewDetails = (branch: BranchesTableRow) => {
     setSelectedBranch(branch);
     setModalMode("view");
     setIsModalOpen(true);
   };
 
-  const handleEditBranch = (branch: Branches) => {
+  const handleEditBranch = (branch: BranchesTableRow) => {
     setSelectedBranch(branch);
     setModalMode("edit");
     setIsModalOpen(true);
@@ -62,12 +72,11 @@ export default function BranchesTable({
     setSelectedBranch(null);
   };
 
-  const columns: Column<Branches>[] = [
+  const columns: Column<BranchesTableRow>[] = [
     { header: "ID", accessor: "id" },
     { header: "Nombre", accessor: "name", filterType: "text" },
     { header: "RIF", accessor: "taxId" },
     { header: "Administrador", accessor: "administrator" },
-    { header: "Ciudad", accessor: "city" },
     {
       header: "País",
       accessor: "country",
@@ -116,7 +125,8 @@ export default function BranchesTable({
         data={data}
         page={page}
         pageSize={10}
-        onPageChange={setPage}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
         enableFilters
         actions={(row) => (
           <div className="flex items-center justify-center gap-2">
@@ -139,10 +149,10 @@ export default function BranchesTable({
           </div>
         )}
       />
-      <BranchDetailsModal
+      {/*<BranchDetailsModal
         isOpen={isModalOpen}
         onClose={handleCloseModal}
-        branchData={selectedBranch}
+        branchData={selectedBranch} // Aquí ya puedes mapear solo los datos que tengas
         initialMode={modalMode}
         allInstructors={allInstructors}
         allCities={allCities}
@@ -151,7 +161,7 @@ export default function BranchesTable({
         allServices={allServices}
         allEquipment={allEquipment}
         allPaymentMethods={allPaymentMethods}
-      />
+      /> */}
     </>
   );
 }

--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -75,7 +75,7 @@ export default function BranchesTable({
   const columns: Column<BranchesTableRow>[] = [
     { header: "ID", accessor: "id" },
     { header: "Nombre", accessor: "name", filterType: "text" },
-    { header: "RIF", accessor: "taxId" },
+    { header: "RIF", accessor: "taxId", filterType: "text" },
     { header: "Administrador", accessor: "administrator" },
     {
       header: "País",
@@ -124,7 +124,7 @@ export default function BranchesTable({
         columns={columns}
         data={data}
         page={page}
-        pageSize={10}
+        pageSize={pageSize}
         onPageChange={onPageChange}
         onPageSizeChange={onPageSizeChange}
         enableFilters
@@ -149,15 +149,16 @@ export default function BranchesTable({
           </div>
         )}
       />
-      {/*<BranchDetailsModal
+      {/*
+    
+    <BranchDetailsModal
         isOpen={isModalOpen}
         onClose={handleCloseModal}
-        branchData={selectedBranch} // Aquí ya puedes mapear solo los datos que tengas
+        branchData={selectedBranch}
         initialMode={modalMode}
         allInstructors={allInstructors}
         allCities={allCities}
         allStates={allStates}
-        allCountries={allCountries}
         allServices={allServices}
         allEquipment={allEquipment}
         allPaymentMethods={allPaymentMethods}

--- a/src/app/(dashboard)/branches/page.tsx
+++ b/src/app/(dashboard)/branches/page.tsx
@@ -12,45 +12,17 @@ import {
   PlusIcon,
 } from "@heroicons/react/24/outline";
 import { useState, useEffect } from "react";
-import { Branches } from "@/types/branches";
 import { Instructor } from "@/types/instructor";
 import { City, State } from "@/types/location";
 import { Service } from "@/types/service";
 import { Equipment } from "@/types/equipment";
 import { PaymentMethod } from "@/types/paymentMethod";
+import {
+  BranchesFetchResult,
+  BranchesTableRow,
+  fetchBranches,
+} from "@/services/branches";
 
-const MOCK_BRANCHES: Branches[] = [
-  {
-    id: "1",
-    name: "Sucursal Centro",
-    taxId: "J-123456",
-    city: "Caracas",
-    country: "Venezuela",
-    status: "active",
-    cityId: "c1",
-    paymethods: [],
-    operatingHours: [],
-    // Campos añadidos para coincidir con el tipo 'Branches'
-    instructors: [],
-    services: [],
-    inventory: [],
-  },
-  {
-    id: "2",
-    name: "Sucursal Este",
-    taxId: "J-654321",
-    city: "Barquisimeto",
-    country: "Venezuela",
-    status: "inactive",
-    cityId: "c2",
-    paymethods: [],
-    operatingHours: [],
-    // Campos añadidos para coincidir con el tipo 'Branches'
-    instructors: [],
-    services: [],
-    inventory: [],
-  },
-];
 const MOCK_INSTRUCTORS: Instructor[] = [
   { id: "i1", user_id: "u1", name: "Ana Pérez" },
   { id: "i2", user_id: "u2", name: "Carlos Rivas" },
@@ -70,17 +42,19 @@ const MOCK_SERVICES: Service[] = [
 const MOCK_EQUIPMENT: Equipment[] = [
   { id: "eq1", name: "Cinta de correr", category: "Cardio" },
 ];
-const MOCK_STATS = { total: 2, active: 1, inactive: 1, maintenance: 0 };
-
-const statCardsConfig = [
-  { title: "Total", valueKey: "total" as keyof typeof MOCK_STATS },
-  { title: "Activas", valueKey: "active" as keyof typeof MOCK_STATS },
-  { title: "Inactivas", valueKey: "inactive" as keyof typeof MOCK_STATS },
-  {
-    title: "Mantenimiento",
-    valueKey: "maintenance" as keyof typeof MOCK_STATS,
-  },
+const statCardsConfig: { title: string; valueKey: keyof StatsData }[] = [
+  { title: "Total", valueKey: "total" },
+  { title: "Activas", valueKey: "active" },
+  { title: "Inactivas", valueKey: "inactive" },
+  { title: "Mantenimiento", valueKey: "maintenance" },
 ];
+
+type StatsData = {
+  total: number;
+  active: number;
+  inactive: number;
+  maintenance: number;
+};
 
 export type PaymentMethodUI = PaymentMethod & {
   icon?: React.ElementType;
@@ -114,7 +88,6 @@ const MOCK_API_PAYMENT_METHODS: PaymentMethod[] = [
 ];
 
 function mapApiPaymentMethodsToUI(methods: PaymentMethod[]): PaymentMethodUI[] {
-  // <-- Use PaymentMethod here
   return methods.map((method) => {
     let IconComponent: React.ElementType | undefined;
     switch (method.type.toLowerCase()) {
@@ -137,44 +110,76 @@ function mapApiPaymentMethodsToUI(methods: PaymentMethod[]): PaymentMethodUI[] {
 
 export default function HomeBranches() {
   const [showModal, setShowModal] = useState(false);
-
-  const [statsData, setStatsData] = useState(MOCK_STATS);
-  const [branchesData, setBranchesData] = useState<Branches[]>([]);
+  const [isLoadingStatic, setIsLoadingStatic] = useState(true);
+  const [isLoadingBranches, setIsLoadingBranches] = useState(true);
+  const [statsData, setStatsData] = useState<StatsData>({
+    total: 0,
+    active: 0,
+    inactive: 0,
+    maintenance: 0,
+  });
+  const [branchesData, setBranchesData] = useState<BranchesTableRow[]>([]);
   const [allInstructors, setAllInstructors] = useState<Instructor[]>([]);
   const [allCities, setAllCities] = useState<City[]>([]);
   const [allStates, setAllStates] = useState<State[]>([]);
   const [allServices, setAllServices] = useState<Service[]>([]);
   const [allEquipment, setAllEquipment] = useState<Equipment[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [allPaymentMethods, setAllPaymentMethods] = useState<PaymentMethodUI[]>(
     [],
   );
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [sort, setSort] = useState<"asc" | "desc">("desc");
+  const [totalBranches, setTotalBranches] = useState(0);
 
   useEffect(() => {
-    async function loadPageData() {
-      setIsLoading(true);
+    async function loadStaticData() {
+      setIsLoadingStatic(true);
       try {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        setBranchesData(MOCK_BRANCHES);
+        setStatsData({ total: 25, active: 15, inactive: 8, maintenance: 2 });
+
+        // CORRECCIÓN #3: Carga los mocks UNA SOLA VEZ
         setAllInstructors(MOCK_INSTRUCTORS);
         setAllCities(MOCK_CITIES);
         setAllStates(MOCK_STATES);
         setAllServices(MOCK_SERVICES);
         setAllEquipment(MOCK_EQUIPMENT);
-        setStatsData(MOCK_STATS);
-        const uiPaymentMethods = mapApiPaymentMethodsToUI(
-          MOCK_API_PAYMENT_METHODS,
+        setAllPaymentMethods(
+          mapApiPaymentMethodsToUI(MOCK_API_PAYMENT_METHODS),
         );
-        setAllPaymentMethods(uiPaymentMethods);
       } catch (error) {
-        console.error("Error cargando los datos:", error);
+        console.error("Error cargando datos estáticos:", error);
       } finally {
-        setIsLoading(false);
+        setIsLoadingStatic(false);
       }
     }
-    loadPageData();
+    loadStaticData();
   }, []);
 
+  useEffect(() => {
+    async function loadBranchesData() {
+      setIsLoadingBranches(true);
+      try {
+        const offset = (page - 1) * pageSize;
+
+        const result = await fetchBranches({
+          limit: pageSize,
+          offset,
+          sort: sort,
+        });
+
+        console.log("Datos recibidos:", result.data);
+        console.log("Total recibido:", result.total);
+        setBranchesData(result.data);
+        setTotalBranches(result.total);
+      } catch (error) {
+        console.error("Error cargando sucursales:", error);
+      } finally {
+        setIsLoadingBranches(false);
+      }
+    }
+    loadBranchesData();
+  }, [page, pageSize, sort]);
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
       <PageHeader title="SUCURSALES">
@@ -200,7 +205,12 @@ export default function HomeBranches() {
       </div>
       <BranchesTable
         data={branchesData}
-        isLoading={isLoading}
+        isLoading={isLoadingBranches}
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalBranches}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
         allInstructors={allInstructors}
         allCities={allCities}
         allStates={allStates}

--- a/src/app/(dashboard)/branches/page.tsx
+++ b/src/app/(dashboard)/branches/page.tsx
@@ -4,6 +4,7 @@ import BranchesTable from "./BranchesTable";
 import { PageHeader } from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
 import BranchFrom from "./BranchForm";
+import { redirect } from "next/navigation";
 import {
   BanknotesIcon,
   BuildingLibraryIcon,
@@ -157,6 +158,10 @@ export default function HomeBranches() {
   }, []);
 
   useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      redirect("/login");
+    }
     async function loadBranchesData() {
       setIsLoadingBranches(true);
       try {
@@ -166,6 +171,8 @@ export default function HomeBranches() {
           limit: pageSize,
           offset,
           sort: sort,
+          token: token,
+          status: "Active",
         });
 
         console.log("Datos recibidos:", result.data);

--- a/src/app/(dashboard)/branches/page.tsx
+++ b/src/app/(dashboard)/branches/page.tsx
@@ -129,22 +129,27 @@ export default function HomeBranches() {
   const [allPaymentMethods, setAllPaymentMethods] = useState<PaymentMethodUI[]>(
     [],
   );
-  const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null);
-  const [detailedBranchData, setDetailedBranchData] = useState<Branches | null>(
-    null,
+  const [filters, setFilters] = useState<Record<string, string | undefined>>(
+    {},
   );
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [sort, setSort] = useState<"asc" | "desc">("desc");
   const [totalBranches, setTotalBranches] = useState(0);
+  const totalPages = Math.ceil(totalBranches / pageSize);
+
+  const handleFilterChange = (key: string, value: string | undefined) => {
+    setPage(1); // Siempre resetear a la página 1 al filtrar
+    setFilters((prevFilters) => ({
+      ...prevFilters,
+      [key]: value,
+    }));
+  };
 
   useEffect(() => {
     async function loadStaticData() {
       setIsLoadingStatic(true);
       try {
-        setStatsData({ total: 25, active: 15, inactive: 8, maintenance: 2 });
-
-        // CORRECCIÓN #3: Carga los mocks UNA SOLA VEZ
         setAllInstructors(MOCK_INSTRUCTORS);
         setAllCities(MOCK_CITIES);
         setAllStates(MOCK_STATES);
@@ -171,19 +176,24 @@ export default function HomeBranches() {
       setIsLoadingBranches(true);
       try {
         const offset = (page - 1) * pageSize;
+        const searchTerms = filters.name || filters.taxId;
+        const statusFilter = filters.status;
 
         const result = await fetchBranches({
           limit: pageSize,
-          offset,
+          offset: offset,
           sort: sort,
           token: token,
-          status: "Active",
+          search: searchTerms,
+          status: statusFilter || "Active",
         });
 
         console.log("Datos recibidos:", result.data);
         console.log("Total recibido:", result.total);
+        console.log("Total stats:", result.stats);
         setBranchesData(result.data);
         setTotalBranches(result.total);
+        setStatsData(result.stats);
       } catch (error) {
         console.error("Error cargando sucursales:", error);
       } finally {
@@ -191,33 +201,7 @@ export default function HomeBranches() {
       }
     }
     loadBranchesData();
-  }, [page, pageSize, sort]);
-
-  const handleSelectBranchForModal = (branchId: string) => {
-    setDetailedBranchData(null);
-    setSelectedBranchId(branchId);
-    setShowModal(true);
-  };
-
-  /*useEffect(() => {
-    if (!selectedBranchId) return;
-
-    async function loadBranchDetails() {
-      try {
-        const token = localStorage.getItem("token");
-        // ASUME que tienes una función fetchBranchDetails(id, token)
-        const details = await fetchBranchDetails(selectedBranchId, token);
-        setDetailedBranchData(details);
-      } catch (error) {
-        console.error(
-          `Error cargando detalles de sucursal ${selectedBranchId}:`,
-          error,
-        );
-        setDetailedBranchData(null);
-      }
-    }
-    loadBranchDetails();
-  }, [selectedBranchId]);*/
+  }, [page, pageSize, sort, filters]);
 
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
@@ -247,7 +231,7 @@ export default function HomeBranches() {
         isLoading={isLoadingBranches}
         page={page}
         pageSize={pageSize}
-        totalCount={totalBranches}
+        totalPages={totalPages}
         onPageChange={setPage}
         onPageSizeChange={setPageSize}
         allInstructors={allInstructors}
@@ -256,7 +240,8 @@ export default function HomeBranches() {
         allServices={allServices}
         allEquipment={allEquipment}
         allPaymentMethods={allPaymentMethods}
-        //onBranchSelect={handleSelectBranchForModal}
+        onFilterChange={handleFilterChange}
+        filterValues={filters}
       />
 
       {showModal && (

--- a/src/app/(dashboard)/branches/page.tsx
+++ b/src/app/(dashboard)/branches/page.tsx
@@ -23,6 +23,7 @@ import {
   BranchesTableRow,
   fetchBranches,
 } from "@/services/branches";
+import { Branches } from "@/types/branches";
 
 const MOCK_INSTRUCTORS: Instructor[] = [
   { id: "i1", user_id: "u1", name: "Ana Pérez" },
@@ -128,6 +129,10 @@ export default function HomeBranches() {
   const [allPaymentMethods, setAllPaymentMethods] = useState<PaymentMethodUI[]>(
     [],
   );
+  const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null);
+  const [detailedBranchData, setDetailedBranchData] = useState<Branches | null>(
+    null,
+  );
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [sort, setSort] = useState<"asc" | "desc">("desc");
@@ -187,6 +192,33 @@ export default function HomeBranches() {
     }
     loadBranchesData();
   }, [page, pageSize, sort]);
+
+  const handleSelectBranchForModal = (branchId: string) => {
+    setDetailedBranchData(null);
+    setSelectedBranchId(branchId);
+    setShowModal(true);
+  };
+
+  /*useEffect(() => {
+    if (!selectedBranchId) return;
+
+    async function loadBranchDetails() {
+      try {
+        const token = localStorage.getItem("token");
+        // ASUME que tienes una función fetchBranchDetails(id, token)
+        const details = await fetchBranchDetails(selectedBranchId, token);
+        setDetailedBranchData(details);
+      } catch (error) {
+        console.error(
+          `Error cargando detalles de sucursal ${selectedBranchId}:`,
+          error,
+        );
+        setDetailedBranchData(null);
+      }
+    }
+    loadBranchDetails();
+  }, [selectedBranchId]);*/
+
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
       <PageHeader title="SUCURSALES">
@@ -224,6 +256,7 @@ export default function HomeBranches() {
         allServices={allServices}
         allEquipment={allEquipment}
         allPaymentMethods={allPaymentMethods}
+        //onBranchSelect={handleSelectBranchForModal}
       />
 
       {showModal && (

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -10,8 +10,8 @@ import {
   type ColumnDef,
   type SortingState,
   type ColumnFiltersState,
-  type Row,
 } from "@tanstack/react-table";
+
 import {
   Table,
   TableHeader,
@@ -22,8 +22,8 @@ import {
 } from "../ui/table";
 import { Checkbox } from "../ui/checkbox";
 import { PaginationControls } from "./PaginationControls";
-import { ArrowUp, ArrowDown } from "lucide-react";
 import { Input } from "../Input";
+import { ArrowUp, ArrowDown } from "lucide-react";
 
 export type Column<T> = {
   header: string;
@@ -37,9 +37,10 @@ export type DataTableProps<T> = {
   columns: Column<T>[];
   data: T[];
   actions?: (row: T) => React.ReactNode;
-  page?: number;
+  page?: number; // controlado por el padre
   pageSize?: number;
   onPageChange?: (page: number) => void;
+  onPageSizeChange?: (size: number) => void;
   enableFilters?: boolean;
   enableRowSelection?: boolean;
 };
@@ -48,12 +49,37 @@ export function DataTable<T>({
   columns,
   data,
   actions,
-  page = 1,
-  pageSize = 10,
+  page,
+  pageSize,
   onPageChange,
+  onPageSizeChange,
   enableFilters = false,
-  enableRowSelection = true, // <-- Corregido: Ahora es 'true' por defecto
+  enableRowSelection = true,
 }: DataTableProps<T>) {
+  // Estado interno híbrido
+  const [internalPage, setInternalPage] = React.useState(1);
+  const [internalPageSize, setInternalPageSize] = React.useState(10);
+
+  const currentPage = page ?? internalPage;
+  const currentPageSize = pageSize ?? internalPageSize;
+
+  const handlePageChange = (newPage: number) => {
+    if (onPageChange) {
+      onPageChange(newPage);
+    } else {
+      setInternalPage(newPage);
+    }
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    if (onPageSizeChange) {
+      onPageSizeChange(newSize);
+    } else {
+      setInternalPageSize(newSize);
+    }
+  };
+
+  // Estado para filtros y sorting
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     [],
@@ -93,12 +119,14 @@ export function DataTable<T>({
     getFilteredRowModel: getFilteredRowModel(),
   });
 
-  const startIndex = (page - 1) * pageSize;
-  const endIndex = startIndex + pageSize;
+  // Slice para paginación
+  const startIndex = (currentPage - 1) * currentPageSize;
+  const endIndex = startIndex + currentPageSize;
   const pageRows = table.getRowModel().rows.slice(startIndex, endIndex);
 
   return (
     <div className="space-y-4">
+      {/* FILTROS */}
       {enableFilters && (
         <div className="flex flex-wrap gap-3 mb-4">
           {columns
@@ -108,19 +136,19 @@ export function DataTable<T>({
               if (!column) {
                 return null;
               }
+
               if (col.filterType === "text") {
                 return (
                   <Input
                     key={String(col.accessor)}
                     placeholder={`Filtrar por ${col.header.toLowerCase()}...`}
                     value={(column.getFilterValue() as string) ?? ""}
-                    onChange={(e) => {
-                      column.setFilterValue(e.target.value);
-                    }}
+                    onChange={(e) => column.setFilterValue(e.target.value)}
                     className="max-w-xs"
                   />
                 );
               }
+
               if (col.filterType === "select" && col.filterOptions) {
                 return (
                   <select
@@ -138,11 +166,13 @@ export function DataTable<T>({
                   </select>
                 );
               }
+
               return null;
             })}
         </div>
       )}
 
+      {/* TABLA */}
       <Table>
         <TableHeader>
           <TableRow>
@@ -211,13 +241,12 @@ export function DataTable<T>({
         </TableBody>
       </Table>
 
-      {onPageChange && (
-        <PaginationControls
-          page={page}
-          totalPages={Math.ceil(data.length / pageSize)}
-          onPageChange={onPageChange}
-        />
-      )}
+      {/* PAGINACIÓN */}
+      <PaginationControls
+        page={currentPage}
+        totalPages={Math.ceil(data.length / currentPageSize)}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 }

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -24,6 +24,14 @@ import { Checkbox } from "../ui/checkbox";
 import { PaginationControls } from "./PaginationControls";
 import { Input } from "../Input";
 import { ArrowUp, ArrowDown } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 
 export type Column<T> = {
   header: string;
@@ -32,6 +40,11 @@ export type Column<T> = {
   filterType?: "text" | "select";
   filterOptions?: { label: string; value: string }[];
 };
+
+export type FilterChangeHandler = (
+  key: string,
+  value: string | undefined,
+) => void;
 
 export type DataTableProps<T> = {
   columns: Column<T>[];
@@ -43,6 +56,9 @@ export type DataTableProps<T> = {
   onPageSizeChange?: (size: number) => void;
   enableFilters?: boolean;
   enableRowSelection?: boolean;
+  totalPages?: number;
+  onFilterChange?: FilterChangeHandler;
+  filterValues?: Record<string, string | undefined>;
 };
 
 export function DataTable<T>({
@@ -53,8 +69,11 @@ export function DataTable<T>({
   pageSize,
   onPageChange,
   onPageSizeChange,
+  totalPages,
   enableFilters = false,
   enableRowSelection = true,
+  onFilterChange,
+  filterValues,
 }: DataTableProps<T>) {
   // Estado interno híbrido
   const [internalPage, setInternalPage] = React.useState(1);
@@ -81,19 +100,21 @@ export function DataTable<T>({
 
   // Estado para filtros y sorting
   const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    [],
-  );
 
   const columnDefs = React.useMemo<ColumnDef<T>[]>(
     () =>
       columns.map((col) => ({
         accessorKey: col.accessor as string,
         header: col.header,
-        cell: ({ getValue, row }) =>
-          col.render
-            ? col.render(getValue() as T[keyof T], row.original)
-            : String(getValue() ?? ""),
+        cell: ({ getValue, row }) => {
+          const value = getValue() as T[keyof T];
+          const originalRow = row.original;
+
+          if (col.render) {
+            return col.render(value, originalRow);
+          }
+          return String(value ?? "");
+        },
         filterFn:
           col.filterType === "select"
             ? (row, columnId, filterValue) =>
@@ -111,18 +132,16 @@ export function DataTable<T>({
   const table = useReactTable({
     data,
     columns: columnDefs,
-    state: { sorting, columnFilters },
+    state: { sorting },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
   });
 
   // Slice para paginación
   const startIndex = (currentPage - 1) * currentPageSize;
   const endIndex = startIndex + currentPageSize;
-  const pageRows = table.getRowModel().rows.slice(startIndex, endIndex);
+  const pageRows = table.getRowModel().rows;
 
   return (
     <div className="space-y-4">
@@ -142,8 +161,13 @@ export function DataTable<T>({
                   <Input
                     key={String(col.accessor)}
                     placeholder={`Filtrar por ${col.header.toLowerCase()}...`}
-                    value={(column.getFilterValue() as string) ?? ""}
-                    onChange={(e) => column.setFilterValue(e.target.value)}
+                    value={filterValues?.[col.accessor as string] ?? ""}
+                    onChange={(e) =>
+                      onFilterChange?.(
+                        col.accessor as string,
+                        e.target.value || undefined,
+                      )
+                    }
                     className="max-w-xs"
                   />
                 );
@@ -151,19 +175,33 @@ export function DataTable<T>({
 
               if (col.filterType === "select" && col.filterOptions) {
                 return (
-                  <select
+                  <Select
                     key={String(col.accessor)}
-                    className="border rounded-md px-2 py-1 text-sm"
-                    value={(column.getFilterValue() as string) ?? ""}
-                    onChange={(e) => column.setFilterValue(e.target.value)}
+                    value={filterValues?.[col.accessor as string] ?? "all"}
+                    onValueChange={(newValue) => {
+                      let finalValue: string | undefined = newValue;
+                      if (newValue === "all") {
+                        finalValue = undefined;
+                      }
+                      onFilterChange?.(col.accessor as string, finalValue);
+                    }}
                   >
-                    <option value="">Todos</option>
-                    {col.filterOptions.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder="Todos" />
+                    </SelectTrigger>
+
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectItem value="all">Todos</SelectItem>
+
+                        {col.filterOptions.map((opt) => (
+                          <SelectItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
                 );
               }
 
@@ -241,10 +279,9 @@ export function DataTable<T>({
         </TableBody>
       </Table>
 
-      {/* PAGINACIÓN */}
       <PaginationControls
         page={currentPage}
-        totalPages={Math.ceil(data.length / currentPageSize)}
+        totalPages={totalPages ?? Math.ceil(data.length / currentPageSize)}
         onPageChange={handlePageChange}
       />
     </div>

--- a/src/services/branches.ts
+++ b/src/services/branches.ts
@@ -18,7 +18,7 @@ export type BranchesTableRow = {
   administrator: string;
   state: string;
   country: string;
-  status: "active" | "inactive" | "maintenance";
+  status: "Active" | "Inactive" | "Maintenance";
 };
 
 export type BranchesFetchResult = {
@@ -37,6 +37,7 @@ interface FetchBranchesParams {
   sort: "asc" | "desc";
   search?: string;
   status?: string;
+  token: string | null;
 }
 
 export async function fetchBranches({
@@ -45,6 +46,7 @@ export async function fetchBranches({
   sort,
   search,
   status,
+  token,
 }: FetchBranchesParams): Promise<BranchesFetchResult> {
   const query = new URLSearchParams();
   query.append("limit", limit.toString());
@@ -59,7 +61,12 @@ export async function fetchBranches({
   }
 
   const res: ApiBranchesResponse = await fetchAPI(
-    `/branches?${query.toString()}`,
+    `/user/branch-admins?${query.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
   );
 
   if (!res.data) {
@@ -74,7 +81,7 @@ export async function fetchBranches({
     administrator: `${b.manager_name} ${b.manager_last_name}`,
     state: b.state_name,
     country: b.country_name,
-    status: b.status as "active" | "inactive" | "maintenance",
+    status: b.status as "Active" | "Inactive" | "Maintenance",
   }));
 
   const total =

--- a/src/services/branches.ts
+++ b/src/services/branches.ts
@@ -1,0 +1,88 @@
+import { fetchAPI } from "@/lib/api";
+
+export interface ApiBranch {
+  branch_id: string;
+  country_name: string;
+  manager_name: string;
+  manager_last_name: string;
+  name: string;
+  state_name: string;
+  status: string;
+  tax_id: string;
+}
+
+export type BranchesTableRow = {
+  id: string;
+  name: string;
+  taxId: string;
+  administrator: string;
+  state: string;
+  country: string;
+  status: "active" | "inactive" | "maintenance";
+};
+
+export type BranchesFetchResult = {
+  data: BranchesTableRow[];
+  total: number;
+};
+
+interface ApiBranchesResponse {
+  data: ApiBranch[];
+  total?: number;
+}
+
+interface FetchBranchesParams {
+  limit: number;
+  offset: number;
+  sort: "asc" | "desc";
+  search?: string;
+  status?: string;
+}
+
+export async function fetchBranches({
+  limit,
+  offset,
+  sort,
+  search,
+  status,
+}: FetchBranchesParams): Promise<BranchesFetchResult> {
+  const query = new URLSearchParams();
+  query.append("limit", limit.toString());
+  query.append("offset", offset.toString());
+  query.append("sort", sort);
+
+  if (search) {
+    query.append("search", search);
+  }
+  if (status) {
+    query.append("status", status);
+  }
+
+  const res: ApiBranchesResponse = await fetchAPI(
+    `/branches?${query.toString()}`,
+  );
+
+  if (!res.data) {
+    console.error("Respuesta de API inválida, falta 'data'");
+    return { data: [], total: 0 };
+  }
+
+  const mappedData: BranchesTableRow[] = res.data.map((b) => ({
+    id: b.branch_id,
+    name: b.name,
+    taxId: b.tax_id,
+    administrator: `${b.manager_name} ${b.manager_last_name}`,
+    state: b.state_name,
+    country: b.country_name,
+    status: b.status as "active" | "inactive" | "maintenance",
+  }));
+
+  const total =
+    res.total ??
+    offset + mappedData.length + (mappedData.length === limit ? 1 : 0);
+
+  return {
+    data: mappedData,
+    total: total,
+  };
+}

--- a/src/services/branches.ts
+++ b/src/services/branches.ts
@@ -21,14 +21,29 @@ export type BranchesTableRow = {
   status: "Active" | "Inactive" | "Maintenance";
 };
 
+type StatsData = {
+  total: number;
+  active: number;
+  inactive: number;
+  maintenance: number;
+};
+
 export type BranchesFetchResult = {
   data: BranchesTableRow[];
   total: number;
+  stats: StatsData;
 };
 
+interface ApiCount {
+  active: number;
+  inactive: number;
+  maintenance: number;
+  total: number;
+}
+
 interface ApiBranchesResponse {
+  count: ApiCount;
   data: ApiBranch[];
-  total?: number;
 }
 
 interface FetchBranchesParams {
@@ -69,10 +84,21 @@ export async function fetchBranches({
     },
   );
 
-  if (!res.data) {
-    console.error("Respuesta de API inválida, falta 'data'");
-    return { data: [], total: 0 };
+  if (!res.data || !res.count) {
+    console.error("Respuesta de API inválida, falta 'data' o 'count'");
+    return {
+      data: [],
+      total: 0,
+      stats: { total: 0, active: 0, inactive: 0, maintenance: 0 },
+    };
   }
+
+  const statsResult: StatsData = {
+    total: res.count.total,
+    active: res.count.active,
+    inactive: res.count.inactive,
+    maintenance: res.count.maintenance,
+  };
 
   const mappedData: BranchesTableRow[] = res.data.map((b) => ({
     id: b.branch_id,
@@ -85,10 +111,11 @@ export async function fetchBranches({
     status: b.status as "Active" | "Inactive" | "Maintenance",
   }));
 
-  const total = res.total ?? mappedData.length;
+  const total = res.count.total;
 
   return {
     data: mappedData,
     total: total,
+    stats: statsResult,
   };
 }

--- a/src/services/branches.ts
+++ b/src/services/branches.ts
@@ -61,7 +61,7 @@ export async function fetchBranches({
   }
 
   const res: ApiBranchesResponse = await fetchAPI(
-    `/user/branch-admins?${query.toString()}`,
+    `/branches?${query.toString()}`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/services/branches.ts
+++ b/src/services/branches.ts
@@ -78,15 +78,14 @@ export async function fetchBranches({
     id: b.branch_id,
     name: b.name,
     taxId: b.tax_id,
-    administrator: `${b.manager_name} ${b.manager_last_name}`,
+    administrator:
+      `${b.manager_name ?? ""} ${b.manager_last_name ?? ""}`.trim(),
     state: b.state_name,
     country: b.country_name,
     status: b.status as "Active" | "Inactive" | "Maintenance",
   }));
 
-  const total =
-    res.total ??
-    offset + mappedData.length + (mappedData.length === limit ? 1 : 0);
+  const total = res.total ?? mappedData.length;
 
   return {
     data: mappedData,


### PR DESCRIPTION
### Cambios Clave

* **Refactorización de Paginación (Server-Side):**
    * Se eliminó la paginación y el *slice* de datos locales en `DataTable.tsx`.
    * Se centralizó el cálculo del total de páginas (`Math.ceil(total / pageSize)`) en `HomeBranches.tsx`.
    * Se asegura que la tabla solo muestre los 10 registros que envía la API para la página actual, manteniendo la consistencia (Pág 1 muestra 10, Pág 2 muestra 2).

* **Integración de Filtros (Server-Side):**
    * Se movió el estado de los filtros (`search`, `status`) de `DataTable` a `HomeBranches.tsx`.
    * Se añadió un *handler* (`onFilterChange`) que reinicia la página a 1 y dispara una nueva llamada a `fetchBranches` con los parámetros `search` y `status`.

* **Stats y API:**
    * Se modificó `fetchBranches` para retornar los `stats` de conteo (`total`, `active`, `inactive`, `maintenance`) extraídos del objeto `count` de la respuesta JSON.
    * Se actualizó `HomeBranches.tsx` para consumir estos *stats* reales, eliminando los *mocks* de conteo.

* **Mejora de UI/Estilos:**
    * Se reemplazó el `<select>` nativo por el componente estilizado de **Radix UI/Shadcn** en `DataTable.tsx` para el filtro de *status*.
    * Se implementó una solución para el error `value=""` de Radix, utilizando el valor de limpieza `'all'` y mapeándolo a `undefined` para la API.