### PR TITLE
feat(servicios): agregar pantalla de servicios

### DIFF
--- a/src/app/(dashboard)/services/ServicesTable.tsx
+++ b/src/app/(dashboard)/services/ServicesTable.tsx
@@ -1,0 +1,180 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import EyeIcon from "@heroicons/react/24/outline/EyeIcon";
+import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
+import StarIconOutline from "@heroicons/react/24/outline/StarIcon";
+import StarIconSolid from "@heroicons/react/24/solid/StarIcon";
+import EllipsisVerticalIcon from "@heroicons/react/24/outline/EllipsisVerticalIcon";
+import { useState } from "react";
+import { Service } from "@/models/service";
+import { ServicesData } from "./data";
+import { Column, DataTable } from "@/components/ui/table/DataTable";
+import { Trash2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { json } from "zod";
+
+type ServiceRow = Service & { featured?: boolean | null };
+
+export default function ServicesTable() {
+  const [deleteRowId, setDeleteRowId] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [selectedService, setSelectedService] = useState<Service | null>(null);
+
+  const handleEditService = (service: Service) => {
+    setSelectedService(service);
+    alert("Editar detalles del servicio " + JSON.stringify(service));
+  };
+  const handleViewDetails = (service: Service) => {
+    setSelectedService(service);
+    alert("Ver detalles del servicio" + JSON.stringify(service));
+  };
+
+  /*const handleDeleteService = async (Service: Service) => { // 'Service' es tu tipo de dato
+    const confirmed = window.confirm(`¿Seguro que deseas eliminar la Promo "${Service.name}"?`);
+    if (!confirmed) {
+      return;
+    }
+  
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        toast.error("Error de autenticación. Intenta iniciar sesión de nuevo.");
+        return;
+      }
+  
+      await deleteService(Service.id, token);
+      to.success("Servicio eliminado correctamente ✅");
+  
+      // ✅ Usa el router de Next.js para refrescar la data sin recargar
+      router.refresh(); 
+  
+    } catch (error) {
+      console.error("Error al eliminar:", error);
+      toast.error("No se pudo eliminar el Servicio ❌");
+    }
+  };*/
+
+  const columns: Column<ServiceRow>[] = [
+    {
+      header: "ID",
+      accessor: "id",
+      render: (id) => (
+        <div className="w-28 truncate text-center" title={id as string}>
+          {id as string}
+        </div>
+      ),
+    },
+    {
+      header: "Nombre",
+      accessor: "name",
+      filterType: "text",
+      filterable: true,
+      render: (v) => <div className="text-center">{v as string}</div>,
+    },
+    {
+      header: "Categoria",
+      accessor: "categoryId",
+      filterType: "text",
+      filterable: true,
+      render: (v) => <div className="text-center">{v as string}</div>,
+    },
+    {
+      header: "Duración",
+      accessor: "durationMinutes",
+      filterType: "text",
+      filterable: false,
+      render: (v) => (
+        <div className="text-center">{v ? `${v} min` : "N/A"}</div>
+      ),
+    },
+    {
+      header: "Destacado",
+      accessor: "featured",
+      render: (v) => (
+        <div className="text-center">
+          {(v as boolean) ? (
+            <StarIconSolid className="h-5 w-5 text-black-500 inline-block" />
+          ) : (
+            <StarIconOutline className="h-5 w-5 text-black-500 inline-block" />
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <DataTable<ServiceRow>
+        columns={columns}
+        data={ServicesData}
+        page={page}
+        pageSize={10}
+        onPageChange={setPage}
+        actions={(row) => (
+          <div className="flex flex-col items-center justify-center w-full">
+            <div className="flex items-center justify-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="icon" variant="ghost" title="Acciones">
+                    <EllipsisVerticalIcon className="h-5 w-5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => handleViewDetails(row)}>
+                    <EyeIcon className="h-4 w-4" />
+                    <span className="ml-2">Ver Detalles</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleEditService(row)}>
+                    <PencilIcon className="h-4 w-4" />
+                    <span className="ml-2">Modificar</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setDeleteRowId(row.id)}>
+                    <Trash2 className="h-4 w-4 text-red-500" />
+                    <span className="ml-2 text-red-500">Eliminar</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            {deleteRowId === row.id && (
+              <Alert className="mt-2 w-full max-w-md">
+                <AlertTitle className="text-black">
+                  Confirmar Eliminación
+                </AlertTitle>
+                <AlertDescription className="text-gray-900">
+                  ¿Estás seguro de que deseas eliminar este servicio? Esta
+                  acción no se puede deshacer.
+                </AlertDescription>
+                <div className="flex justify-end gap-2 mt-4">
+                  <Button
+                    variant="outline"
+                    className="border-white"
+                    onClick={() => setDeleteRowId(null)}
+                  >
+                    Cancelar
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    className="text-white"
+                    onClick={() => {
+                      setDeleteRowId(null);
+                      alert(`Servicio eliminado: ${row.name}`);
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4 text-white" />
+                    Eliminar
+                  </Button>
+                </div>
+              </Alert>
+            )}
+          </div>
+        )}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/services/data.ts
+++ b/src/app/(dashboard)/services/data.ts
@@ -1,0 +1,33 @@
+import { Service } from "@/models/service";
+
+export const ServicesData: (Service & { featured?: boolean })[] = [
+  {
+    id: "001",
+    name: "Clase de Yoga Vinyasa",
+    categoryId: "Clases Grupales",
+
+    durationMinutes: 5,
+    featured: true,
+  },
+  {
+    id: "002",
+    name: "Plan Nutricional Básico",
+    categoryId: "Nutrición",
+    durationMinutes: 5,
+    featured: true,
+  },
+  {
+    id: "004",
+    name: "Acceso a Sala de Pesas",
+    categoryId: "Acceso Gimnasio",
+    durationMinutes: null,
+    featured: false,
+  },
+  {
+    id: "005",
+    name: "Acceso a Sala de Pesas",
+    categoryId: "Acceso Gimnasio",
+    durationMinutes: null,
+    featured: false,
+  },
+];

--- a/src/app/(dashboard)/services/page.tsx
+++ b/src/app/(dashboard)/services/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { PlusIcon } from "@heroicons/react/24/outline";
+import ServicesTable from "./ServicesTable";
+import { StatCard } from "@/components/ui/StatCard";
+
+const statsData = {
+  total: 6,
+  active: 5,
+  featured: 2,
+};
+
+const statCardsConfig = [
+  {
+    title: "Total",
+    valueKey: "total" as keyof typeof statsData,
+    fontColor: "text-black-600",
+  },
+  {
+    title: "Activos",
+    valueKey: "active" as keyof typeof statsData,
+    fontColor: "text-green-600",
+  },
+  {
+    title: "Destacados",
+    valueKey: "featured" as keyof typeof statsData,
+    fontColor: "text-yellow-600",
+  },
+];
+
+export default function Services() {
+  return (
+    <div className="flex-1 space-y-8 p-8 pt-6">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {statCardsConfig.map((card) => (
+          <StatCard
+            key={card.title}
+            title={card.title}
+            value={
+              <>
+                {card.valueKey === "total"
+                  ? statsData.active + statsData.featured + statsData.total
+                  : (statsData[card.valueKey] ?? 0)}
+                <span className={`ml-1.5 font-normal ${card.fontColor} `}>
+                  SERVICIOS
+                </span>
+              </>
+            }
+          />
+        ))}
+      </div>
+
+      <PageHeader title="SERVICIOS">
+        <Button variant="primary">
+          <PlusIcon className="h-5 w-5" />
+          Agregar Servicios
+        </Button>
+      </PageHeader>
+
+      <ServicesTable />
+    </div>
+  );
+}

--- a/src/components/ui/table/DataTable.tsx
+++ b/src/components/ui/table/DataTable.tsx
@@ -113,7 +113,9 @@ export function DataTable<T extends object>({
         id: "actions",
         header: "Acciones",
         cell: ({ row }) => (
-          <div className="flex justify-end gap-2">{actions(row.original)}</div>
+          <div className="flex justify-center gap-2">
+            {actions(row.original)}
+          </div>
         ),
       });
     }

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -7,6 +7,5 @@ export type Service = {
   id: string;
   name: string;
   categoryId: string;
-  description?: string | null;
   durationMinutes?: number | null;
 };


### PR DESCRIPTION
Se implementó una nueva pantalla para la gestión de servicios utilizando el componente DataTable. La vista permite visualizar los servicios disponibles en formato tabular, con columnas dinámicas y opciones de ordenamiento. Esta estructura facilita la lectura, búsqueda y futura integración de acciones como edición o eliminación. La pantalla está diseñada para mantener consistencia con el resto del dashboard.