### PR TITLE
feat(sucursal): agregar funcionalidad de eliminar en la pantalla

### DIFF
--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -9,6 +9,7 @@ import { Service } from "@/models/service";
 import { Equipment } from "@/models/equipment";
 import { PaymentMethodUI } from "./page";
 import { Column, DataTable } from "@/components/ui/table/DataTable";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { PaginatedBranch } from "@vitalfit/sdk";
 import { Input } from "@/components/ui/Input";
 import {
@@ -18,16 +19,9 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 import { SelectValue } from "@radix-ui/react-select";
-import {
-  CopyIcon,
-  Download,
-  Eye,
-  Pencil,
-  Search,
-  Trash2,
-  X,
-} from "lucide-react";
+import { Download, Eye, Pencil, Search, Trash2, X } from "lucide-react";
 import { RowActions } from "@/components/ui/table/RowActions";
+import { deleteBranch } from "@/services/branches";
 
 export type FilterChangeHandler = (
   key: string,
@@ -66,6 +60,7 @@ export default function BranchesTable({
   totalPages,
   onPageChange,
   onPageSizeChange,
+  onBranchDeleted,
 }: BranchesTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedBranch, setSelectedBranch] = useState<PaginatedBranch | null>(
@@ -77,6 +72,11 @@ export default function BranchesTable({
     Record<string, string>
   >({});
 
+  const [deleteRowId, setDeleteRowId] = useState<string | null>(null);
+  const [pendingRow, setPendingRow] = useState<BranchRow | null>(null);
+  const [deleteSuccess, setDeleteSuccess] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   const handleView = (row: BranchRow) => {
     console.log("Ver detalles de la sucursal:", row.branch_id, row.name);
   };
@@ -85,8 +85,33 @@ export default function BranchesTable({
     console.log("Editar sucursal:", row.branch_id, row.name);
   };
 
-  const handleDelete = (row: BranchRow) => {
-    console.log("Eliminar sucursal:", row.branch_id, row.name);
+  const confirmDelete = (row: BranchRow) => {
+    setPendingRow(row);
+    setDeleteRowId(row.branch_id); // activa el Alert
+  };
+
+  const handleDelete = async () => {
+    if (!pendingRow) {return;}
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setDeleteError("Token no disponible. No se pudo eliminar la sucursal.");
+      return;
+    }
+
+    try {
+      await deleteBranch(pendingRow.branch_id, token);
+      setDeleteSuccess(`Sucursal eliminada: ${pendingRow.name}`);
+      if (typeof onBranchDeleted === "function") {
+        await onBranchDeleted();
+      }
+    } catch (error) {
+      setDeleteError("Error al eliminar la sucursal. Intenta nuevamente.");
+      console.error("Error al eliminar:", error);
+    } finally {
+      setDeleteRowId(null);
+      setPendingRow(null);
+    }
   };
 
   const columns: Column<PaginatedBranch>[] = [
@@ -151,6 +176,16 @@ export default function BranchesTable({
     return () => clearTimeout(timer);
   }, [inputFilters]);
 
+  useEffect(() => {
+    if (deleteSuccess || deleteError) {
+      const timer = setTimeout(() => {
+        setDeleteSuccess(null);
+        setDeleteError(null);
+      }, 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [deleteSuccess, deleteError]);
+
   return (
     <>
       <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
@@ -204,6 +239,50 @@ export default function BranchesTable({
         </div>
       </div>
 
+      {deleteRowId && pendingRow && (
+        <Alert className="mt-2 w-full max-w-md">
+          <AlertTitle className="text-black">Confirmar Eliminación</AlertTitle>
+          <AlertDescription className="text-gray-900">
+            ¿Estás seguro de que deseas eliminar este servicio? Esta acción no
+            se puede deshacer.
+          </AlertDescription>
+          <div className="flex justify-end gap-2 mt-4">
+            <Button
+              variant="outline"
+              className="border-white"
+              onClick={() => {
+                setDeleteRowId(null);
+                setPendingRow(null);
+              }}
+            >
+              Cancelar
+            </Button>
+            <Button
+              variant="destructive"
+              className="text-white"
+              onClick={handleDelete}
+            >
+              <Trash2 className="h-4 w-4 text-white" />
+              Eliminar
+            </Button>
+          </div>
+        </Alert>
+      )}
+
+      {deleteSuccess && (
+        <Alert className="w-full max-w-md border-green-300 bg-white text-green-800 mb-4">
+          <AlertTitle>Eliminación exitosa</AlertTitle>
+          <AlertDescription>{deleteSuccess}</AlertDescription>
+        </Alert>
+      )}
+
+      {deleteError && (
+        <Alert className="w-full max-w-md border-red-300 bg-white text-red-800 mb-4">
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{deleteError}</AlertDescription>
+        </Alert>
+      )}
+
       <DataTable
         columns={columns}
         data={data}
@@ -225,7 +304,7 @@ export default function BranchesTable({
               {
                 label: "Eliminar",
                 icon: Trash2,
-                onClick: () => handleDelete(row),
+                onClick: () => confirmDelete(row),
                 variant: "danger",
                 separatorBefore: true,
               },


### PR DESCRIPTION
Título
Corrección: se habilita la eliminación de sucursales desde el listado.
Descripción
Se agregó la funcionalidad de eliminar sucursales directamente desde la pantalla de listado. Esta opción no estaba disponible previamente, lo que impedía gestionar correctamente las sucursales desde la interfaz principal.
Issue relacionado
Este PR responde a una omisión funcional que impedía eliminar sucursales desde el listado. Si existe un issue abierto que documenta este problema, por favor enlazarlo aquí.
Motivación y contexto
La ausencia de la opción de eliminar sucursales desde la pantalla principal representaba una limitación en la gestión operativa. Esta corrección permite realizar dicha acción de forma directa, mejorando la experiencia del usuario y alineando la funcionalidad con el resto del módulo.
Cómo se ha probado?
Se probó la eliminación en entorno local con múltiples sucursales activas.

Se verificó que la acción elimina correctamente la sucursal en el backend.

Se confirmó que la UI se actualiza sin errores ni inconsistencias.

Se validó que no se afectan otras funcionalidades de la pantalla ni del módulo.
<img width="1906" height="969" alt="eliminar" src="https://github.com/user-attachments/assets/4a6f3abd-bdc3-4128-b8e6-d57c800e0c85" />
<img width="1898" height="978" alt="eliminar2" src="https://github.com/user-attachments/assets/c43c2241-5f03-4a8f-ac00-5a1d60c0409a" />
