### PR TITLE
refactor(branches): migrate branch deletion to use SDK

### DIFF
--- a/src/app/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/(dashboard)/branches/BranchesTable.tsx
@@ -22,6 +22,7 @@ import { SelectValue } from "@radix-ui/react-select";
 import { Download, Eye, Pencil, Search, Trash2, X } from "lucide-react";
 import { RowActions } from "@/components/ui/table/RowActions";
 import { deleteBranch } from "@/services/branches";
+import { api } from "@/lib/sdk-config";
 
 export type FilterChangeHandler = (
   key: string,
@@ -87,31 +88,35 @@ export default function BranchesTable({
 
   const confirmDelete = (row: BranchRow) => {
     setPendingRow(row);
-    setDeleteRowId(row.branch_id); // activa el Alert
+    setDeleteRowId(row.branch_id);
   };
 
   const handleDelete = async () => {
-    if (!pendingRow) {return;}
+    if (!pendingRow) {
+      return;
+    }
 
     const token = localStorage.getItem("token");
     if (!token) {
       setDeleteError("Token no disponible. No se pudo eliminar la sucursal.");
       return;
     }
-
-    try {
-      await deleteBranch(pendingRow.branch_id, token);
-      setDeleteSuccess(`Sucursal eliminada: ${pendingRow.name}`);
-      if (typeof onBranchDeleted === "function") {
-        await onBranchDeleted();
-      }
-    } catch (error) {
-      setDeleteError("Error al eliminar la sucursal. Intenta nuevamente.");
-      console.error("Error al eliminar:", error);
-    } finally {
-      setDeleteRowId(null);
-      setPendingRow(null);
-    }
+    api.branch
+      .delete(pendingRow.branch_id, token)
+      .then(() => {
+        setDeleteSuccess(`Sucursal eliminada: ${pendingRow.name}`);
+        if (typeof onBranchDeleted === "function") {
+          onBranchDeleted();
+        }
+      })
+      .catch((error) => {
+        setDeleteError("Error al eliminar la sucursal. Intenta nuevamente.");
+        console.error("Error al eliminar (directo del SDK):", error);
+      })
+      .finally(() => {
+        setDeleteRowId(null);
+        setPendingRow(null);
+      });
   };
 
   const columns: Column<PaginatedBranch>[] = [


### PR DESCRIPTION
## Descripción
Se corrije  la lógica de borrado de sucursal para usar el método oficial del SDK en lugar de una llamada manual con `fetch`.

## Issue Relacionado
## Motivación y Contexto

Migrar al SDK **soluciona este error** al asegurar que todas las respuestas del API se manejen correctamente y que se muestre la notificación apropiada (de éxito o error) al usuario. Esto también alinea el módulo con el estándar del proyecto de usar el SDK para todas las interacciones con el API.

## ¿Cómo se ha probado esto?
He probado esto manualmente en mi entorno local.

1.  **Caso Exitoso:**
    * Hice clic en "Borrar" en una sucursal.
    * Confirmé el borrado.
    * Verifiqué que se llamó al endpoint del SDK, que la sucursal se eliminó de la lista y que apareció una **notificación de éxito**.

2.  **Caso de Fallo (Prueba):**
    * Hice clic en "Borrar" en una sucursal.

## Capturas de Pantalla (si aplica):
N/A (Sin cambios visuales, solo mejora de lógica).

<img width="632" height="207" alt="Screenshot 2025-11-01 135949" src="https://github.com/user-attachments/assets/ac5e3753-687b-4e9b-b254-ee7a6720328c" />
<img width="664" height="126" alt="Screenshot 2025-11-01 135955" src="https://github.com/user-attachments/assets/f02de42e-3b30-49d3-9bde-bb58b3f1870e" />
