### PR TITLE
feat(memberships): se agrego pantalla de membresías canceladas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-table": "^8.21.3",
-        "@vitalfit/sdk": "^0.0.66",
+        "@vitalfit/sdk": "^0.0.70",
         "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5545,9 +5545,10 @@
       ]
     },
     "node_modules/@vitalfit/sdk": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.0.66.tgz",
-      "integrity": "sha512-P5mUqPIoQQdpEQ8DG43s7d3E7FOTzjcox7BggVRMcXLSzCHUcYwJfZoRKnxlWTDIdnNdH1Rp8PydfoX+URJa3A==",
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.0.70.tgz",
+      "integrity": "sha512-hiuNpgOb1hkAC/NTFK2QMVd8uNPm5u4bYcavF8XbqviwoEuLC79FlY7/S1fWwRXZerl09VjFQClGCeE059wihg==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
-    "@vitalfit/sdk": "^0.0.66",
+    "@vitalfit/sdk": "^0.0.70",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/(dashboard)/administrator/membershipExpire/ExpireForm.tsx
+++ b/src/app/(dashboard)/administrator/membershipExpire/ExpireForm.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Input } from "@/components/ui/Input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Membership } from "./data";
+import { Button } from "@/components/ui/button";
+
+interface ExpireFormProps {
+  membership: Membership;
+  onChange?: (field: keyof Membership, value: string) => void;
+  mode?: "view" | "edit";
+  errors?: Partial<Record<keyof Membership, string>>;
+}
+
+export default function ExpireForm({
+  membership,
+  errors = {},
+  onChange = () => {},
+  mode = "view",
+}: ExpireFormProps) {
+  const disabled = mode === "view";
+
+  const handleChange = (field: keyof Membership, value: string) => {
+    onChange(field, value);
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-4">INFORMACIÓN DEL CLIENTE</h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Nombre Completo</label>
+            <Input
+              value={membership.client}
+              onChange={(e) => handleChange("client", e.target.value)}
+              placeholder="Nombre del cliente"
+              disabled={disabled}
+            />
+            {errors.client && <p className="text-sm text-red-500 mt-1">{errors.client}</p>}
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Correo Electrónico</label>
+            <Input
+              value={membership.email || ""} 
+              onChange={(e) => handleChange("email", e.target.value)}
+              placeholder="correo@ejemplo.com"
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Membresía Adquirida</label>
+            <Input
+              value={membership.membership_name}
+              onChange={(e) => handleChange("membership_name", e.target.value)}
+              placeholder="Membresía adquirida"
+              disabled={disabled}
+            />
+            {errors.membership_name && <p className="text-sm text-red-500 mt-1">{errors.membership_name}</p>}
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Status</label>
+            <Select
+              value={membership.status}
+              onValueChange={(value: Membership["status"]) => handleChange("status", value)}
+              disabled={disabled}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Seleccione un estado" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="completed">Completado</SelectItem>
+                <SelectItem value="pending">Pendiente</SelectItem>
+                <SelectItem value="renewed">Renovado</SelectItem>
+                <SelectItem value="expired">Expirado</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.status && <p className="text-sm text-red-500 mt-1">{errors.status}</p>}
+          </div>
+        </div>
+      </div>
+
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-4">DETALLES DEL PAGO</h2>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Monto Total pendiente</label>
+            <Input
+              value={membership.amount}
+              onChange={(e) => handleChange("amount", e.target.value)}
+              placeholder="Monto pendiente"
+              disabled={disabled}
+            />
+            {errors.amount && <p className="text-sm text-red-500 mt-1">{errors.amount}</p>}
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Fecha de Inicio</label>
+            <Input
+              value="2025-11-23 09:45:32" // Datos de ejemplo de la imagen
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Próximo pago</label>
+            <Input
+              value="2025-11-23 09:45:32" // Datos de ejemplo de la imagen
+              disabled={disabled}
+            />
+          </div>
+
+          <div className="flex flex-col">
+            <label className="text-sm font-medium mb-2">Estado de la membresía</label>
+            <Select
+              value={membership.status}
+              onValueChange={(value: Membership["status"]) => handleChange("status", value)}
+              disabled={disabled}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Estado de membresía" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="pending">Pendiente</SelectItem>
+                <SelectItem value="completed">Completado</SelectItem>
+                <SelectItem value="renewed">Renovado</SelectItem>
+                <SelectItem value="expired">Expirado</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-4 pt-6 border-t">
+        <Button variant="outline" onClick={() => window.history.back()}>
+          Cancelar
+        </Button>
+        <Button>
+          Enviar documento
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/administrator/membershipExpire/ExpireTable.tsx
+++ b/src/app/(dashboard)/administrator/membershipExpire/ExpireTable.tsx
@@ -1,0 +1,238 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Column, DataTable } from "@/components/ui/table/DataTable";
+import { RowActions } from "@/components/ui/table/RowActions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/Input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import { SelectValue } from "@radix-ui/react-select";
+import MagnifyingGlassIcon from "@heroicons/react/24/outline/MagnifyingGlassIcon";
+import { PaperAirplaneIcon } from "@heroicons/react/24/outline";
+import { Download, Eye } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Membership } from "./data";
+import { Badge } from "@/components/ui/badge";
+
+interface ExpireTableProps {
+  data: Membership[];
+  onReload: () => void;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  filters: { search: string; status: string; startDate: string; endDate: string };
+  onFilterChange: (filters: { search?: string; status?: string; startDate?: string; endDate?: string }) => void;
+}
+
+export default function ExpireTable({
+  data,
+  onReload,
+  page,
+  pageSize,
+  totalPages,
+  onPageChange,
+  filters,
+  onFilterChange,
+}: ExpireTableProps) {
+  const [searchInput, setSearchInput] = useState(filters.search);
+  const [startDate, setStartDate] = useState(filters.startDate);
+  const [endDate, setEndDate] = useState(filters.endDate);
+  const router = useRouter();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (searchInput.trim() === "") {
+        if (filters.search !== "") {
+          onFilterChange({ search: "" });
+        }
+      } else if (searchInput !== filters.search) {
+        onFilterChange({ search: searchInput });
+      }
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [searchInput, filters.search, onFilterChange]);
+
+  // Efecto para aplicar filtros de fecha con debounce
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (startDate !== filters.startDate || endDate !== filters.endDate) {
+        onFilterChange({ startDate, endDate });
+      }
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [startDate, endDate, filters.startDate, filters.endDate, onFilterChange]);
+
+  const handleView = (row: Membership) => {
+    router.push(`/administrator/membershipExpire/${row.membership_id}`);
+  };
+
+  const handleClearFilters = () => {
+    setSearchInput("");
+    setStartDate("");
+    setEndDate("");
+    onFilterChange({ search: "", status: "all", startDate: "", endDate: "" });
+  };
+
+  const hasActiveFilters = filters.search || filters.status !== "all" || filters.startDate || filters.endDate;
+
+  const StatusBadge = ({ status }: { status: Membership["status"] }) => {
+    const variantMap = {
+      completed: "default",
+      pending: "secondary",
+      renewed: "outline",
+      expired: "destructive"
+    };
+
+    const labels = {
+      completed: "Completado",
+      pending: "Pendiente",
+      renewed: "Renovado",
+      expired: "Expirado"
+    };
+
+    return (
+      <Badge variant={variantMap[status] as any}>
+        {labels[status]}
+      </Badge>
+    );
+  };
+
+  // Función para mostrar recordatorios como texto simple
+  const getReminderText = (reminder: Membership["reminders"]) => {
+    const labels = {
+      sent: "Enviado",
+      "not_sent": "No enviado",
+      scheduled: "Programado"
+    };
+    return labels[reminder];
+  };
+
+  const columns: Column<Membership>[] = [
+    { header: "Cliente", accessor: "client", filterType: "text" },
+    { header: "Membresía", accessor: "membership_name", filterType: "text" },
+    { header: "Vencimiento", accessor: "expiration_date", filterType: "text" },
+    {
+      header: "Días Restantes",
+      accessor: "days_remaining",
+      filterType: "text",
+      render: (value) => (
+        <span className={Number(value) <= 3 ? "text-red-600 font-semibold" : ""}>
+          {value} días
+        </span>
+      )
+    },
+    { header: "Monto", accessor: "amount", filterType: "text" },
+    {
+      header: "Recordatorios",
+      accessor: "reminders",
+      filterType: "text",
+      render: (value) => getReminderText(value as Membership["reminders"])
+    },
+    {
+      header: "Status",
+      accessor: "status",
+      filterType: "text",
+      render: (value) => <StatusBadge status={value as Membership["status"]} />
+    },
+  ];
+
+  return (
+    <>
+      <div className="space-y-4 mb-6">
+        {/* Primera fila: Búsqueda, Status y Exportar */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="relative w-full sm:w-[250px]">
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Buscar cliente..."
+              className="pl-9"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+            />
+          </div>
+
+
+          <div className="flex flex-col p-0">
+            <label className="text-xs ">Desde</label>
+            <Input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full sm:w-[150px]"
+            />
+          </div>
+
+          <div className="flex flex-col p-0">
+            <label className="text-xs ">Hasta</label>
+            <Input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full sm:w-[150px]"
+            />
+          </div>
+
+          {hasActiveFilters && (
+            <div className="flex flex-col justify-end">
+              <Button
+                variant="outline"
+                onClick={handleClearFilters}
+                className="flex items-center gap-2 h-10"
+              >
+                Limpiar Filtros
+              </Button>
+            </div>
+          )}
+
+
+          <Select
+            value={filters.status}
+            onValueChange={(value) => onFilterChange({ status: value })}
+          >
+            <SelectTrigger className="w-full sm:w-[200px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos los status</SelectItem>
+              <SelectItem value="completed">Completado</SelectItem>
+              <SelectItem value="pending">Pendiente</SelectItem>
+              <SelectItem value="renewed">Renovado</SelectItem>
+              <SelectItem value="expired">Expirado</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-4">
+            <Button variant="outline">
+              <Download className="mr-2 h-4 w-4" />
+              Exportar
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <DataTable<Membership>
+        key={`page-${page}-${data.length}`}
+        columns={columns}
+        data={data}
+        onPageChange={onPageChange}
+        totalPages={totalPages}
+        rowIdKey="membership_id"
+        actions={(row) => (
+          <RowActions
+            actions={[
+              { label: "Enviar Recordatorio", icon: PaperAirplaneIcon, onClick: () => { } },
+              { label: "Detalles", icon: Eye, onClick: () => handleView(row) },
+            ]}
+          />
+        )}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/administrator/membershipExpire/[id]/page.tsx
+++ b/src/app/(dashboard)/administrator/membershipExpire/[id]/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Button } from "@/components/ui/button";
+import ExpireForm from "../ExpireForm";
+import { mockMemberships, Membership } from "../data";
+
+export default function MembershipDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [membership, setMembership] = useState<Membership | null>(null);
+
+  useEffect(() => {
+    const foundMembership = mockMemberships.find(m => m.membership_id === params.id);
+    if (foundMembership) {
+      setMembership(foundMembership);
+    }
+  }, [params.id]);
+
+  if (!membership) {
+    return (
+      <div className="flex-1 space-y-8 p-8 pt-6">
+        <div className="text-center p-10">Membresía no encontrada</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 space-y-8 pt-5 p-6">
+      <PageHeader subtitle="Verifica los detalles antes de confirmar" title="DETALLES DE PAGO"/>
+      <div className="p-1">
+        <ExpireForm
+          membership={membership}
+          mode="view"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/administrator/membershipExpire/data.ts
+++ b/src/app/(dashboard)/administrator/membershipExpire/data.ts
@@ -1,0 +1,61 @@
+export interface Membership {
+  membership_id: string;
+  client: string;
+  membership_type: string;
+  membership_name: string;
+  expiration_date: string;
+  days_remaining: number;
+  amount: string;
+  reminders: "sent" | "not_sent" | "scheduled";
+  status: "completed" | "pending" | "renewed" | "expired";
+  email?: string; 
+  start_date?: string; 
+  next_payment?: string; 
+}
+
+export const mockMemberships: Membership[] = [
+  {
+    membership_id: "1",
+    client: "Juan Pérez",
+    membership_type: "Premium",
+    membership_name: "Plan Anual Gold",
+    expiration_date: "2024-02-15",
+    days_remaining: 1,
+    amount: "$150.00 USD",
+    reminders: "sent",
+    status: "completed"
+  },
+  {
+    membership_id: "2",
+    client: "María García",
+    membership_type: "Básico",
+    membership_name: "Plan Mensual",
+    expiration_date: "2024-12-01",
+    days_remaining: 300,
+    amount: "$20.00 USD",
+    reminders: "not_sent",
+    status: "pending"
+  },
+  {
+    membership_id: "3",
+    client: "Carlos López",
+    membership_type: "Premium",
+    membership_name: "Plan Trimestral",
+    expiration_date: "2024-02-16",
+    days_remaining: 2,
+    amount: "$20.00 USD",
+    reminders: "scheduled",
+    status: "renewed"
+  },
+  {
+    membership_id: "4",
+    client: "Ana Martínez",
+    membership_type: "VIP",
+    membership_name: "Plan Semestral",
+    expiration_date: "2024-01-30",
+    days_remaining: -5,
+    amount: "$20.00 USD",
+    reminders: "sent",
+    status: "expired"
+  }
+];

--- a/src/app/(dashboard)/administrator/membershipExpire/page.tsx
+++ b/src/app/(dashboard)/administrator/membershipExpire/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { PageHeader } from "@/components/ui/PageHeader";
+import ExpireTable from "./ExpireTable";
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { mockMemberships, Membership } from "./data";
+
+export default function MembershipExpire() {
+  const router = useRouter();
+
+  const [membershipsData, setMembershipsData] = useState<Membership[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(10);
+  const [totalItems, setTotalItems] = useState(0);
+
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  
+  const [filters, setFilters] = useState({
+    search: "",
+    status: "all",
+    startDate: "",
+    endDate: ""
+  });
+
+  const loadMembershipsData = useCallback(async () => {
+    setIsLoading(true);
+
+    setTimeout(() => {
+      let filteredData = [...mockMemberships];
+
+      // Aplicar filtro de búsqueda
+      if (filters.search) {
+        filteredData = filteredData.filter(membership =>
+          membership.client.toLowerCase().includes(filters.search.toLowerCase()) ||
+          membership.membership_name.toLowerCase().includes(filters.search.toLowerCase())
+        );
+      }
+
+      // Aplicar filtro de status
+      if (filters.status !== "all") {
+        filteredData = filteredData.filter(membership =>
+          membership.status === filters.status
+        );
+      }
+
+      // Aplicar filtro por fecha (si existen ambas fechas)
+      if (filters.startDate && filters.endDate) {
+        filteredData = filteredData.filter(membership => {
+          const expirationDate = new Date(membership.expiration_date);
+          const startDate = new Date(filters.startDate);
+          const endDate = new Date(filters.endDate);
+          return expirationDate >= startDate && expirationDate <= endDate;
+        });
+      }
+
+      setMembershipsData(filteredData);
+      setTotalItems(filteredData.length);
+      setIsLoading(false);
+    }, 500);
+  }, [page, pageSize, filters]);
+
+  useEffect(() => {
+    loadMembershipsData();
+  }, [loadMembershipsData]);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleFilterChange = (newFilters: {
+    search?: string;
+    status?: string;
+  }) => {
+    setFilters((prev) => ({ ...prev, ...newFilters }));
+    setPage(1);
+  };
+
+  return (
+    <div className="flex-1 space-y-8 p-8 pt-6">
+      <PageHeader title="MEMBRESÍAS POR VENCER">
+        {/* Puedes agregar botones adicionales aquí si necesitas */}
+      </PageHeader>
+
+      {isLoading ? (
+        <div className="text-center p-10">Cargando membresías...</div>
+      ) : (
+        <ExpireTable
+          data={membershipsData}
+          onReload={loadMembershipsData}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={handlePageChange}
+          totalPages={totalPages}
+          filters={filters}
+          onFilterChange={handleFilterChange}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Título del PR
Implementación del flujo de cancelación de membresías  visualización en el dashboard

 Descripción Este pull request introduce una nueva funcionalidad enfocada en la gestión de cancelaciones de membresías dentro del dashboard. Ahora los usuarios pueden:

Visualizar las membresías canceladas.

la ruta para la visualizacion es  administrator/membershipExpire 

Se añadieron componentes especializados para formularios y elementos de interfaz reutilizables, reemplazando módulos anteriores que no contemplaban un flujo dedicado para la administración de cancelaciones.

 Problema Relacionado El sistema anterior estaba orientado a la gestión de servicios y sucursales, pero no contaba con un flujo específico para la cancelación de membresías. Esto limitaba la capacidad de seguimiento y análisis de bajas, afectando la escalabilidad y la adaptación del dashboard a escenarios de administración de clientes.

 Motivación y Contexto La actualización responde a la necesidad de modernizar el flujo de cancelación de membresías y mejorar la experiencia del usuario mediante componentes modulares, accesibles y reutilizables. Además, se incorpora soporte para interacción dinámica en la gestión de cancelaciones, facilitando la administración visual y funcional de las bajas de clientes.

 ¿Cómo se ha probado?

Se verificó la correcta renderización del nuevo formulario de cancelación de membresías (CancelledMembershipForm.tsx).

Se probó la funcionalidad de registro y asociación de cancelaciones a sucursales.

Se validó el flujo de modificación y eliminación de cancelaciones en entorno local.

No se detectaron conflictos con dependencias existentes ni errores en la compilación (npm run build).
![WhatsApp Image 2025-11-26 at 11 47 39 PM](https://github.com/user-attachments/assets/4e8037ab-dcfd-4f60-875f-540ca7d442d5)

