### PR TITLE
feat(i18n): agregar soporte de idioma en 'Sucursal' y 'Membresía'

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -239,6 +239,7 @@
     "services": {
       "title": "SERVICES",
       "add_button": "Add Service",
+      "id_prefix": "Service ID",
       "stats": {
         "total": "Total",
         "actives": "Actives",
@@ -454,6 +455,101 @@
         "edit_button": "Modify",
         "loading": "Loading...",
         "not_found": "Payment method not found"
+      }
+    },
+    "memberships": {
+      "title": "MEMBERSHIPS",
+      "add_button": "Add Membership",
+      "loading": "Loading Memberships...",
+      "table": {
+        "placeholder": "Search membership by name",
+        "download": "Download",
+        "columns": {
+          "name": "Name",
+          "description": "Description",
+          "duration": "Duration (days)",
+          "price": "Price",
+          "status": "Status"
+        },
+        "status": {
+          "active": "Active",
+          "inactive": "Inactive"
+        },
+        "actions": {
+          "view": "View Details",
+          "edit": "Modify",
+          "delete": "Delete"
+        },
+        "delete_dialog": {
+          "title": "Confirm Deletion",
+          "description": "Are you sure you want to delete this membership? This action cannot be undone.",
+          "confirm": "Delete",
+          "cancel": "Cancel"
+        }
+      },
+      "form": {
+        "labels": {
+          "name": "Name*",
+          "description": "Description*",
+          "duration_days": "Duration (Days)*",
+          "price": "Price ($)*",
+          "status": "Status"
+        },
+        "placeholders": {
+          "name": "E.g.: Premium Membership",
+          "description": "E.g.: Unlimited access to all facilities",
+          "duration_days": "E.g.: 30",
+          "price": "E.g.: 99.99"
+        }
+      },
+      "create": {
+        "title": "CREATE MEMBERSHIP",
+        "subtitle": "Add the membership information",
+        "button_create": "Create",
+        "button_saving": "Saving...",
+        "success": "Membership created successfully!",
+        "error_connection": "Connection Error",
+        "error_connection_description": "Could not connect to the server. Try again later.",
+        "error_create": "Error creating membership",
+        "error_auth": "Authentication token not found."
+      },
+      "edit": {
+        "title": "MODIFY MEMBERSHIP",
+        "subtitle": "Modify the membership information {name}",
+        "button_cancel": "Cancel",
+        "button_save": "Save Changes",
+        "button_saving": "Saving...",
+        "success": "Membership updated successfully!",
+        "error_connection": "Connection Error",
+        "error_connection_description": "Could not connect to the server. Try again later.",
+        "error_update": "Error updating membership",
+        "error_load": "Could not load membership information.",
+        "error_auth": "Authentication token not found."
+      },
+      "view": {
+        "title": "MEMBERSHIP DETAILS",
+        "button_edit": "Modify",
+        "loading": "Loading Memberships...",
+        "error_load": "Could not load membership information.",
+        "error_auth": "Session expired or unauthorized. Please log in again.",
+        "not_found": "Membership not found or unavailable."
+      },
+      "notifications": {
+        "delete_success": "Membership deleted successfully",
+        "delete_error": "Error deleting membership. Try again.",
+        "delete_auth_error": "You are not authenticated to perform this action."
+      },
+      "validations": {
+        "name_required": "Name is required",
+        "name_max": "Name cannot exceed 100 characters",
+        "description_required": "Description is required",
+        "description_max": "Description cannot exceed 500 characters",
+        "duration_int": "Duration must be an integer",
+        "duration_min": "Duration cannot be zero (0) or negative",
+        "duration_max": "Maximum duration is 3650 days (10 years)",
+        "price_min": "Price cannot be zero (0) or negative",
+        "price_max": "Maximum price is 999,999.99",
+        "validation_error": "Unexpected validation error"
       }
     }
   },
@@ -839,6 +935,331 @@
       "error_subtitle": "Could not load client information",
       "not_found": "Client not found",
       "back_button": "Back to list"
+    }
+  },
+  "branches": {
+    "title": "BRANCHES",
+    "add_button": "Create Branch",
+    "stats": {
+      "total": "Total",
+      "active": "Active",
+      "inactive": "Inactive",
+      "maintenance": "Maintenance",
+      "unit": "BRANCHES"
+    },
+    "table": {
+      "placeholder": "Search by name or RIF",
+      "filter_status": "Status",
+      "clear_filters": "Clear filters",
+      "download": "Download CSV",
+      "columns": {
+        "name": "Name",
+        "tax_id": "taxId",
+        "manager": "Manager",
+        "country": "Country",
+        "status": "Status"
+      },
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive",
+        "maintenance": "Under maintenance",
+        "unknown": "Unknown"
+      },
+      "actions": {
+        "view": "View",
+        "edit": "Modify",
+        "delete": "Delete"
+      },
+      "delete_dialog": {
+        "title": "Confirm Deletion",
+        "description": "Are you sure you want to delete this branch? This action cannot be undone.",
+        "confirm": "Delete",
+        "cancel": "Cancel",
+        "success": "Branch deleted: {name}",
+        "error": "Error deleting the branch. Please try again.",
+        "success_title": "Successfully deleted",
+        "error_title": "Error"
+      }
+    },
+    "create": {
+      "title": "CREATE NEW BRANCH",
+      "subtitle": "Complete the following steps to create a new branch",
+      "steps": {
+        "basic": {
+          "name": "Basic Information",
+          "description": "Data"
+        },
+        "location": {
+          "name": "Location",
+          "description": "Address"
+        },
+        "admin": {
+          "name": "Administration",
+          "description": "Management"
+        },
+        "confirm": {
+          "name": "Confirmation",
+          "description": "Review"
+        }
+      },
+      "form": {
+        "basic_info": {
+          "title": "Basic Branch Information",
+          "subtitle": "Start by entering the fundamental data of the new branch.",
+          "name": "Legal Name *",
+          "name_placeholder": "E.g.: FitnessPlaza",
+          "tax_id": "Tax ID *",
+          "tax_id_placeholder": "J-402456696-3",
+          "phone": "Phone",
+          "phone_placeholder": "Phone",
+          "status": "Branch Status *",
+          "status_placeholder": "Active",
+          "next_steps": {
+            "title": "Next steps",
+            "description": "In the following steps we will configure the location, contact, schedules and employees of the new branch."
+          }
+        },
+        "location": {
+          "title": "Location and Contact",
+          "subtitle": "Select the exact location on the map or enter coordinates",
+          "address": "Full Address*",
+          "address_placeholder": "Enter address manually or select on map",
+          "state": "State",
+          "country": "Country",
+          "gps_coords": "GPS Coordinates",
+          "latitude": "Latitude",
+          "longitude": "Longitude"
+        },
+        "admin": {
+          "title": "Management",
+          "subtitle": "Assign the responsible manager, define the capacity and configure the operating hours for each day of the week",
+          "manager": "Responsible Manager *",
+          "manager_placeholder": "Select a Manager",
+          "capacity": "Member Capacity *",
+          "capacity_placeholder": "Example: 400",
+          "table": {
+            "day": "Day",
+            "opening": "Opening",
+            "closing": "Closing",
+            "closed": "Closed"
+          },
+          "days": {
+            "monday": "Monday",
+            "tuesday": "Tuesday",
+            "wednesday": "Wednesday",
+            "thursday": "Thursday",
+            "friday": "Friday",
+            "saturday": "Saturday",
+            "sunday": "Sunday"
+          }
+        },
+        "confirm": {
+          "title": "Commercial Policies",
+          "subtitle": "Select the corresponding commercial policies for the branch",
+          "checkbox_label": "Select by checking the policies",
+          "footer_hint": "These policies will be visible to the members of this branch",
+          "next_steps": {
+            "title": "Ready to create",
+            "description": "Review the information before confirming. Once the branch is created, you can modify these data from the branch management."
+          },
+          "policies": {
+            "p1": "Totally free registration for a limited time.",
+            "p2": "Flexible membership with a minimum cancellation period of only 1 month.",
+            "p3": "Access to on-site personal trainer at no additional cost at each schedule.",
+            "p4": "Specialized classes for adults +50 years old.",
+            "p5": "'Bring a friend' benefit: 15 days of free access for a companion.",
+            "p6": "Diversity of group classes included: Dance, Boxing, Yoga and more.",
+            "p7": "Exclusive/free parking for members.",
+            "p8": "Commitment to safety: Secure and monitored facilities for a worry-free experience."
+          }
+        },
+        "buttons": {
+          "back": "Back",
+          "next": "Next",
+          "create": "Create Branch",
+          "save": "Save changes",
+          "saving": "Saving..."
+        }
+      }
+    },
+    "details": {
+      "title": "Branch Details",
+      "edit_title": "Modify Branch",
+      "info_of": "Information of {name}",
+      "loading": "Loading branch...",
+      "not_found": "Branch not found.",
+      "error_loading": "Could not load branch information.",
+      "tabs": {
+        "basic": "General",
+        "payment": "Payment methods",
+        "services": "Services",
+        "instructors": "Instructors",
+        "equipment": "Equipment"
+      },
+      "basic": {
+        "title": "Basic information",
+        "subtitle": "Legal and general data of the branch",
+        "name": "Legal name",
+        "tax_id": "Tax ID",
+        "phone": "Phone",
+        "capacity": "Maximum capacity",
+        "status": "Branch status",
+        "status_placeholder": "Select a status",
+        "hint": "This data must correspond with the legal documentation of the branch.",
+        "location_title": "Location",
+        "location_subtitle": "Visualizing the location of the branch",
+        "map_title": "Map position",
+        "schedule_title": "Operating hours",
+        "success_update": "Branch updated successfully",
+        "error_update": "Error updating branch"
+      },
+      "payment_methods": {
+        "title": "Accepted payment methods",
+        "subtitle": "Select the payment methods that will be available in this branch.",
+        "placeholder": "Select a method...",
+        "add": "Add",
+        "empty": "No payment methods selected.",
+        "type": "Type: {type}",
+        "remove": "Remove",
+        "success_load": "Branch payment methods loaded successfully",
+        "error_load": "Could not load payment methods",
+        "error_branch_load": "Could not load branch payment methods",
+        "success_add": "Payment method \"{name}\" added",
+        "success_remove": "Payment method removed successfully",
+        "error_remove": "Could not remove payment method",
+        "saving": "Saving payment methods...",
+        "success_save": "Payment methods saved successfully",
+        "error_save": "Could not save payment methods"
+      },
+      "equipment": {
+        "error_loading_catalog": "Error loading equipment catalog",
+        "error_loading_inventory": "Error loading inventory",
+        "select_before_adding": "You must select an equipment before adding it",
+        "error_adding": "Error adding equipment: {errors}",
+        "success_added_pending": "Equipment \"{name}\" added to pending inventory",
+        "success_removed_pending": "Equipment \"{name}\" removed from pending inventory",
+        "success_removed": "Equipment \"{name}\" removed from inventory",
+        "error_invalid_token": "Invalid token",
+        "success_save": "Changes saved successfully",
+        "error_save": "Error saving changes",
+        "error_invalid_update": "Invalid equipment for update",
+        "error_update": "Error updating equipment: {errors}",
+        "success_update": "Equipment \"{name}\" updated successfully",
+        "error_updating": "Error updating equipment",
+        "table": {
+          "name": "Name",
+          "serial": "Serial",
+          "status": "Status",
+          "acquisition": "Acquisition",
+          "last_maintenance": "Last Maintenance"
+        },
+        "actions": {
+          "view": "View equipment",
+          "edit": "Edit equipment",
+          "delete": "Delete equipment"
+        },
+        "add": {
+          "title": "Add new equipment",
+          "search_label": "Search equipment",
+          "search_placeholder": "E.g.: Monster Power Rack",
+          "select_placeholder": "Select an equipment (E.g.: Monster Power Rack)",
+          "serial_label": "Serial number",
+          "serial_placeholder": "E.g.: SN-ROG-123",
+          "notes_label": "Notes",
+          "notes_placeholder": "E.g.: Equipment ready to use",
+          "button": "Add"
+        },
+        "inventory_title": "Branch inventory",
+        "empty": "No equipment assigned to this branch.",
+        "modal": {
+          "edit": "Edit equipment",
+          "view": "View equipment",
+          "loading": "Loading...",
+          "last_maintenance": "Last maintenance",
+          "notes": "Notes",
+          "status": "Status",
+          "status_placeholder": "Select status",
+          "save": "Save"
+        }
+      },
+      "instructors": {
+        "error_loading": "Could not load instructors",
+        "already_assigned": "Instructor is already assigned",
+        "success_added_pending": "Instructor added (pending save)",
+        "success_removed_local": "Instructor removed locally",
+        "success_removed": "Instructor removed successfully",
+        "error_removing": "Could not remove instructor",
+        "no_changes": "No changes to save",
+        "success_save": "Changes saved successfully",
+        "error_save": "Could not save changes",
+        "add_label": "Add instructor",
+        "select_placeholder": "Select an instructor",
+        "add_button": "Add",
+        "loading": "Loading instructors...",
+        "empty": "No instructors assigned.",
+        "remove": "Remove",
+        "info_scroll": "There are many instructors, use the scroll to see more."
+      },
+      "services": {
+        "success_load_catalog": "Branch services loaded successfully",
+        "error_load_catalog": "Could not load available services",
+        "error_load_branch": "Could not load branch services",
+        "success_added": "Service \"{name}\" added",
+        "success_removed": "Service \"{name}\" removed",
+        "error_removing": "Could not remove service",
+        "no_new_services": "No new services to save",
+        "success_save": "Services saved successfully",
+        "error_save": "Error saving services",
+        "success_update": "Service \"{name}\" updated",
+        "error_update": "Error updating service",
+        "title": "Branch services",
+        "subtitle": "Manage available services and their prices.",
+        "add": {
+          "title": "Add new service",
+          "select_placeholder": "Select a service",
+          "capacity": "Capacity",
+          "member_price": "Member price",
+          "non_member_price": "Non-member price",
+          "visible": "Visible",
+          "button": "Add"
+        },
+        "assigned_title": "Assigned services",
+        "loading": "Loading services...",
+        "empty": "No services assigned.",
+        "description": "Capacity: {capacity} | Members: ${memberPrice} | Non-members: ${nonMemberPrice} | Visible: {visible}",
+        "yes": "Yes",
+        "no": "No",
+        "modal": {
+          "view": "View service",
+          "edit": "Edit service",
+          "loading": "Loading...",
+          "capacity": "Maximum capacity",
+          "member_price": "Member price",
+          "non_member_price": "Non-member price",
+          "visible": "Visible",
+          "save": "Save"
+        }
+      }
+    },
+    "notifications": {
+      "success_title": "Branch Created!",
+      "success_description": "The new branch has been successfully registered in the system.",
+      "action_text": "Understood",
+      "error_required": "Please complete the required fields: Name, Tax ID, Country and State."
+    },
+    "validations": {
+      "name_required": "Legal Name is required.",
+      "tax_id_required": "Tax ID is required.",
+      "status_required": "Branch status is required.",
+      "address_required": "Full Address is required.",
+      "location_required": "You must select the location on the map.",
+      "country_required": "Country is required.",
+      "state_required": "State is required.",
+      "manager_required": "You must assign a Responsible Manager.",
+      "capacity_required": "Capacity must be a valid number (> 0).",
+      "opening_required": "Opening time is required",
+      "closing_required": "Closing time is required",
+      "payment_method_required": "You must select at least one payment method"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -239,6 +239,7 @@
     "services": {
       "title": "SERVICIOS",
       "add_button": "Agregar Servicio",
+      "id_prefix": "Servicio ID",
       "stats": {
         "total": "Total",
         "actives": "Activos",
@@ -455,6 +456,101 @@
         "loading": "Cargando...",
         "not_found": "Método de pago no encontrado"
       }
+    },
+    "memberships": {
+      "title": "MEMBRESÍAS",
+      "add_button": "Agregar una membresía",
+      "loading": "Cargando Membresías...",
+      "table": {
+        "placeholder": "Buscar membresía por nombre",
+        "download": "Descargar",
+        "columns": {
+          "name": "Nombre",
+          "description": "Descripción",
+          "duration": "Duración (días)",
+          "price": "Precio",
+          "status": "Status"
+        },
+        "status": {
+          "active": "Activa",
+          "inactive": "Inactiva"
+        },
+        "actions": {
+          "view": "Ver Detalles",
+          "edit": "Modificar",
+          "delete": "Eliminar"
+        },
+        "delete_dialog": {
+          "title": "Confirmar eliminación",
+          "description": "¿Estás seguro de que deseas eliminar esta membresía? Esta acción no se puede deshacer.",
+          "confirm": "Eliminar",
+          "cancel": "Cancelar"
+        }
+      },
+      "form": {
+        "labels": {
+          "name": "Nombre*",
+          "description": "Descripción*",
+          "duration_days": "Duración (Días)*",
+          "price": "Precio ($)*",
+          "status": "Status"
+        },
+        "placeholders": {
+          "name": "Ej: Membresía Premium",
+          "description": "Ej: Acceso ilimitado a todas las instalaciones",
+          "duration_days": "Ej: 30",
+          "price": "Ej: 99.99"
+        }
+      },
+      "create": {
+        "title": "CREAR MEMBRESÍA",
+        "subtitle": "Agrega la información de la membresía",
+        "button_create": "Crear",
+        "button_saving": "Guardando...",
+        "success": "Membresía creada exitosamente!",
+        "error_connection": "Error de conexión",
+        "error_connection_description": "No se pudo conectar con el servidor. Intenta más tarde.",
+        "error_create": "Error al crear membresía",
+        "error_auth": "Token de autenticación no encontrado."
+      },
+      "edit": {
+        "title": "MODIFICAR MEMBRESÍA",
+        "subtitle": "Modifica la información de la membresía {name}",
+        "button_cancel": "Cancelar",
+        "button_save": "Guardar Cambios",
+        "button_saving": "Guardando...",
+        "success": "Membresía actualizado exitosamente!",
+        "error_connection": "Error de conexión",
+        "error_connection_description": "No se pudo conectar con el servidor. Intenta más tarde.",
+        "error_update": "Error al actualizar membresia",
+        "error_load": "No se pudo cargar la información de la membresía.",
+        "error_auth": "Token de autenticación no encontrado."
+      },
+      "view": {
+        "title": "DETALLES DE MEMBRESÍA",
+        "button_edit": "Modificar",
+        "loading": "Cargando Membresías...",
+        "error_load": "No se pudo cargar la información de la membresía.",
+        "error_auth": "Sesión expirada o no autorizada. Intenta ingresar de nuevo.",
+        "not_found": "Membresía no encontrada o no disponible."
+      },
+      "notifications": {
+        "delete_success": "Membresía eliminada correctamente",
+        "delete_error": "Error al eliminar la membresía. Intenta nuevamente.",
+        "delete_auth_error": "No estás autenticado para realizar esta acción."
+      },
+      "validations": {
+        "name_required": "El nombre es requerido",
+        "name_max": "El nombre no puede tener más de 100 caracteres",
+        "description_required": "La descripción es requerida",
+        "description_max": "La descripción no puede tener más de 500 caracteres",
+        "duration_int": "La duración debe ser un número entero",
+        "duration_min": "La duración no puede ser cero (0) o negativa",
+        "duration_max": "La duración máxima es 3650 días (10 años)",
+        "price_min": "El precio no puede cero (0) o negativo",
+        "price_max": "El precio máximo es 999,999.99",
+        "validation_error": "Error de validación inesperado"
+      }
     }
   },
   "cancellationReason": {
@@ -493,101 +589,101 @@
         "error": "Could not delete the reason"
       }
     },
-  "Promotions": {
-    "title": "PROMOCIONES Y DESCUENTOS",
-    "add_button": "Agregar Promoción",
-    "error_loading": "Error al cargar promociones",
-    "stats": {
-      "total": "Total",
-      "active": "Activas",
-      "inactive": "Inactivas",
-      "unit": "Promos"
-    },
-    "table": {
-      "columns": {
-        "promotion": "Promoción",
-        "benefit": "Beneficio",
-        "validity": "Vigencia",
-        "status": "Estatus"
+    "Promotions": {
+      "title": "PROMOCIONES Y DESCUENTOS",
+      "add_button": "Agregar Promoción",
+      "error_loading": "Error al cargar promociones",
+      "stats": {
+        "total": "Total",
+        "active": "Activas",
+        "inactive": "Inactivas",
+        "unit": "Promos"
       },
-      "status": {
-        "active": "Activa",
-        "inactive": "Inactiva",
-        "expired": "Expirada"
+      "table": {
+        "columns": {
+          "promotion": "Promoción",
+          "benefit": "Beneficio",
+          "validity": "Vigencia",
+          "status": "Estatus"
+        },
+        "status": {
+          "active": "Activa",
+          "inactive": "Inactiva",
+          "expired": "Expirada"
+        },
+        "filters": {
+          "search_placeholder": "Buscar por nombre o código...",
+          "clear": "Limpiar"
+        },
+        "export": "Exportar",
+        "delete_dialog": {
+          "title": "¿Eliminar promoción?",
+          "description": "Esta acción no se puede deshacer. Se eliminará permanentemente la promoción \"{name}\".",
+          "confirm": "Eliminar",
+          "cancel": "Cancelar"
+        }
       },
-      "filters": {
-        "search_placeholder": "Buscar por nombre o código...",
-        "clear": "Limpiar"
+      "actions": {
+        "view": "Ver detalles",
+        "edit": "Editar",
+        "delete": "Eliminar",
+        "delete_loading": "Eliminando promoción...",
+        "delete_success": "Promoción eliminada correctamente",
+        "delete_error": "Error al eliminar"
       },
-      "export": "Exportar",
-      "delete_dialog": {
-        "title": "¿Eliminar promoción?",
-        "description": "Esta acción no se puede deshacer. Se eliminará permanentemente la promoción \"{name}\".",
-        "confirm": "Eliminar",
-        "cancel": "Cancelar"
+      "form": {
+        "labels": {
+          "name": "Nombre de la Promoción",
+          "code": "Código (Cupón)",
+          "type": "Tipo de Descuento",
+          "value": "Valor del Descuento",
+          "start_date": "Fecha de Inicio",
+          "end_date": "Fecha de Finalización",
+          "is_active": "Promoción activa y visible"
+        },
+        "placeholders": {
+          "name": "Ej: Verano Fitness",
+          "code": "VERANO2025",
+          "type": "Seleccionar tipo",
+          "percentage": "Porcentaje (%)",
+          "fixed": "Monto Fijo ($)"
+        }
+      },
+      "create": {
+        "title": "NUEVA PROMOCIÓN",
+        "subtitle": "Configure los detalles del cupón para sus socios.",
+        "button_cancel": "Cancelar",
+        "button_submit": "Crear Promoción",
+        "button_loading": "Guardando...",
+        "success_title": "¡Promoción creada!",
+        "success_description": "El código {code} ha sido registrado exitosamente.",
+        "error_title": "Error al guardar",
+        "error_default": "Ocurrió un problema con los datos enviados."
+      },
+      "edit": {
+        "title": "EDITAR PROMOCIÓN",
+        "subtitle": "Modifica los parámetros de la promoción seleccionada para actualizar sus beneficios.",
+        "loading": "Cargando datos de la promoción...",
+        "error_fetch": "No se pudo cargar la promoción",
+        "not_found": "Promoción no encontrada",
+        "success_update": "Promoción actualizada correctamente",
+        "error_update": "Error al actualizar",
+        "button_cancel": "Cancelar",
+        "button_submit": "Actualizar Promoción",
+        "button_loading": "Guardando cambios...",
+        "error_update_description": "No se detectaron cambios para guardar."
+      },
+      "details": {
+        "title": "DETALLES DE LA PROMOCIÓN",
+        "subtitle": "Información detallada sobre el cupón, vigencia y beneficios configurados.",
+        "not_found": "Promoción no encontrada",
+        "loading": "Cargando detalles...",
+        "error_fetch": "No se pudo cargar la información de la promoción",
+        "button_back": "Volver",
+        "button_edit": "Modificar",
+        "button_list": "Volver al listado"
       }
-    },
-    "actions": {
-      "view": "Ver detalles",
-      "edit": "Editar",
-      "delete": "Eliminar",
-      "delete_loading": "Eliminando promoción...",
-      "delete_success": "Promoción eliminada correctamente",
-      "delete_error": "Error al eliminar"
-    },
-    "form": {
-      "labels": {
-        "name": "Nombre de la Promoción",
-        "code": "Código (Cupón)",
-        "type": "Tipo de Descuento",
-        "value": "Valor del Descuento",
-        "start_date": "Fecha de Inicio",
-        "end_date": "Fecha de Finalización",
-        "is_active": "Promoción activa y visible"
-      },
-      "placeholders": {
-        "name": "Ej: Verano Fitness",
-        "code": "VERANO2025",
-        "type": "Seleccionar tipo",
-        "percentage": "Porcentaje (%)",
-        "fixed": "Monto Fijo ($)"
-      }
-    },
-    "create": {
-      "title": "NUEVA PROMOCIÓN",
-      "subtitle": "Configure los detalles del cupón para sus socios.",
-      "button_cancel": "Cancelar",
-      "button_submit": "Crear Promoción",
-      "button_loading": "Guardando...",
-      "success_title": "¡Promoción creada!",
-      "success_description": "El código {code} ha sido registrado exitosamente.",
-      "error_title": "Error al guardar",
-      "error_default": "Ocurrió un problema con los datos enviados."
-    },
-    "edit": {
-      "title": "EDITAR PROMOCIÓN",
-      "subtitle": "Modifica los parámetros de la promoción seleccionada para actualizar sus beneficios.",
-      "loading": "Cargando datos de la promoción...",
-      "error_fetch": "No se pudo cargar la promoción",
-      "not_found": "Promoción no encontrada",
-      "success_update": "Promoción actualizada correctamente",
-      "error_update": "Error al actualizar",
-      "button_cancel": "Cancelar",
-      "button_submit": "Actualizar Promoción",
-      "button_loading": "Guardando cambios...",
-      "error_update_description": "No se detectaron cambios para guardar."
-    },
-    "details": {
-      "title": "DETALLES DE LA PROMOCIÓN",
-      "subtitle": "Información detallada sobre el cupón, vigencia y beneficios configurados.",
-      "not_found": "Promoción no encontrada",
-      "loading": "Cargando detalles...",
-      "error_fetch": "No se pudo cargar la información de la promoción",
-      "button_back": "Volver",
-      "button_edit": "Modificar",
-      "button_list": "Volver al listado"
     }
-  }
   },
   "common": {
     "Validations": {
@@ -839,6 +935,331 @@
       "error_subtitle": "No se pudo cargar la información del cliente",
       "not_found": "Cliente no encontrado",
       "back_button": "Volver a la lista"
+    }
+  },
+  "branches": {
+    "title": "SUCURSALES",
+    "add_button": "Crear Sucursal",
+    "stats": {
+      "total": "Total",
+      "active": "Activas",
+      "inactive": "Inactivas",
+      "maintenance": "Mantenimiento",
+      "unit": "SUCURSALES"
+    },
+    "table": {
+      "placeholder": "Buscar por nombre o RIF",
+      "filter_status": "Estatus",
+      "clear_filters": "Limpiar filtros",
+      "download": "Download CSV",
+      "columns": {
+        "name": "Nombre",
+        "tax_id": "taxId",
+        "manager": "Administrador",
+        "country": "País",
+        "status": "Estado"
+      },
+      "status": {
+        "active": "Activa",
+        "inactive": "Inactiva",
+        "maintenance": "En mantenimiento",
+        "unknown": "Desconocido"
+      },
+      "actions": {
+        "view": "Ver",
+        "edit": "Modificar",
+        "delete": "Eliminar"
+      },
+      "delete_dialog": {
+        "title": "Confirmar Eliminación",
+        "description": "¿Estás seguro de que deseas eliminar este servicio? Esta acción no se puede deshacer.",
+        "confirm": "Eliminar",
+        "cancel": "Cancelar",
+        "success": "Sucursal eliminada: {name}",
+        "error": "Error al eliminar la sucursal. Intenta nuevamente.",
+        "success_title": "Eliminación exitosa",
+        "error_title": "Error"
+      }
+    },
+    "create": {
+      "title": "CREAR NUEVA SUCURSAL",
+      "subtitle": "Complete los siguientes pasos para crear una nueva sucursal",
+      "steps": {
+        "basic": {
+          "name": "Información Básica",
+          "description": "Datos"
+        },
+        "location": {
+          "name": "Ubicación",
+          "description": "Dirección"
+        },
+        "admin": {
+          "name": "Administración",
+          "description": "Gestión"
+        },
+        "confirm": {
+          "name": "Confirmación",
+          "description": "Revisión"
+        }
+      },
+      "form": {
+        "basic_info": {
+          "title": "Información Básica de la Sucursal",
+          "subtitle": "Comience ingresando los datos fundamentales de la nueva sucursal.",
+          "name": "Razón Social *",
+          "name_placeholder": "Ej: FitnesPlaza",
+          "tax_id": "RIF *",
+          "tax_id_placeholder": "J-402456696-3",
+          "phone": "Teléfono",
+          "phone_placeholder": "Teléfono",
+          "status": "Estado de Sucursal *",
+          "status_placeholder": "Activa",
+          "next_steps": {
+            "title": "Próximos pasos",
+            "description": "En los siguientes pasos configuraremos la ubicación, contacto, horarios y empleados de la nueva sucursal."
+          }
+        },
+        "location": {
+          "title": "Ubicación y Contacto",
+          "subtitle": "Seleccione la ubicación exacta en el mapa o ingrese coordenadas",
+          "address": "Dirección Completa*",
+          "address_placeholder": "Ingrese la dirección manualmente o seleccione en el mapa",
+          "state": "Estado",
+          "country": "País",
+          "gps_coords": "Coordenadas GPS",
+          "latitude": "Latitud",
+          "longitude": "Longitud"
+        },
+        "admin": {
+          "title": "Administración",
+          "subtitle": "Asigne el gerente responsable, defina la capacidad y configure los horarios de operación para cada día de la semana",
+          "manager": "Gerente Responsable *",
+          "manager_placeholder": "Seleccione un Gerente",
+          "capacity": "Capacidad de Miembros *",
+          "capacity_placeholder": "Ejemplo: 400",
+          "table": {
+            "day": "Día",
+            "opening": "Apertura",
+            "closing": "Cierre",
+            "closed": "Cerrado"
+          },
+          "days": {
+            "monday": "Lunes",
+            "tuesday": "Martes",
+            "wednesday": "Miércoles",
+            "thursday": "Jueves",
+            "friday": "Viernes",
+            "saturday": "Sábado",
+            "sunday": "Domingo"
+          }
+        },
+        "confirm": {
+          "title": "Políticas Comerciales",
+          "subtitle": "Seleccionas las políticas comerciales correspondientes para la sucursal",
+          "checkbox_label": "Selecciona dándole al check las políticas",
+          "footer_hint": "Estas políticas serán visibles para los miembros de esta sucursal",
+          "next_steps": {
+            "title": "Listo para crear",
+            "description": "Revise la información antes de confirmar. Una vez creada la sucursal, podrá modificar estos datos desde la gestión de sucursales."
+          },
+          "policies": {
+            "p1": "Inscripción totalmente gratuita por tiempo limitado.",
+            "p2": "Membresía flexible con un periodo mínimo de cancelación de solo 1 mes.",
+            "p3": "Acceso a entrenador personal de planta sin costo adicional en cada horario.",
+            "p4": "Clases especializadas para adultos +50 años.",
+            "p5": "Beneficio 'Trae un amigo': 15 días de acceso gratuito para un acompañante.",
+            "p6": "Diversidad de clases grupales incluidas: Baile, Boxeo, Yoga y más.",
+            "p7": "Estacionamiento exclusivo/gratuito para miembros.",
+            "p8": "Compromiso con la seguridad: Instalaciones seguras y monitoreadas para una experiencia libre de preocupaciones."
+          }
+        },
+        "buttons": {
+          "back": "Anterior",
+          "next": "Siguiente",
+          "create": "Crear Sucursal",
+          "save": "Guardar cambios",
+          "saving": "Guardando..."
+        }
+      }
+    },
+    "details": {
+      "title": "Detalles de sucursal",
+      "edit_title": "Modificar Sucursal",
+      "info_of": "Información de {name}",
+      "loading": "Cargando sucursal...",
+      "not_found": "No se encontró la sucursal.",
+      "error_loading": "No se pudo cargar la información de la sucursal.",
+      "tabs": {
+        "basic": "General",
+        "payment": "Métodos de pago",
+        "services": "Servicios",
+        "instructors": "Instructores",
+        "equipment": "Equipamiento"
+      },
+      "basic": {
+        "title": "Información básica",
+        "subtitle": "Datos legales y generales de la sucursal",
+        "name": "Razón social",
+        "tax_id": "RIF",
+        "phone": "Teléfono",
+        "capacity": "Capacidad máxima",
+        "status": "Estado de la sucursal",
+        "status_placeholder": "Selecciona un estado",
+        "hint": "Estos datos deben corresponder con la documentación legal de la sucursal.",
+        "location_title": "Ubicación",
+        "location_subtitle": "Visualizando la ubicación de la sucursal",
+        "map_title": "Posición en el mapa",
+        "schedule_title": "Horarios de operación",
+        "success_update": "Sucursal actualizada correctamente",
+        "error_update": "Error actualizando sucursal"
+      },
+      "payment_methods": {
+        "title": "Métodos de pago aceptados",
+        "subtitle": "Selecciona los métodos de pago que estarán disponibles en esta sucursal.",
+        "placeholder": "Selecciona un método...",
+        "add": "Agregar",
+        "empty": "No hay métodos de pago seleccionados.",
+        "type": "Tipo: {type}",
+        "remove": "Eliminar",
+        "success_load": "Métodos de pago de la sucursal cargados correctamente",
+        "error_load": "No se pudieron cargar los métodos de pago",
+        "error_branch_load": "No se pudieron cargar los métodos de pago de la sucursal",
+        "success_add": "Método de pago \"{name}\" agregado",
+        "success_remove": "Método de pago eliminado correctamente",
+        "error_remove": "No se pudo eliminar el método de pago",
+        "saving": "Guardando métodos de pago...",
+        "success_save": "Métodos de pago guardados correctamente",
+        "error_save": "No se pudieron guardar los métodos de pago"
+      },
+      "equipment": {
+        "error_loading_catalog": "Error cargando catálogo de equipos",
+        "error_loading_inventory": "Error cargando inventario",
+        "select_before_adding": "Debes seleccionar un equipo antes de agregarlo",
+        "error_adding": "Error al agregar equipo: {errors}",
+        "success_added_pending": "Equipo \"{name}\" agregado al inventario pendiente",
+        "success_removed_pending": "Equipo \"{name}\" eliminado del inventario pendiente",
+        "success_removed": "Equipo \"{name}\" eliminado del inventario",
+        "error_invalid_token": "Token inválido",
+        "success_save": "Cambios guardados correctamente",
+        "error_save": "Error guardando cambios",
+        "error_invalid_update": "Equipo inválido para actualizar",
+        "error_update": "Error al actualizar equipo: {errors}",
+        "success_update": "Equipo \"{name}\" actualizado correctamente",
+        "error_updating": "Error actualizando equipamiento",
+        "table": {
+          "name": "Nombre",
+          "serial": "Serial",
+          "status": "Estado",
+          "acquisition": "Adquisición",
+          "last_maintenance": "Último mantenimiento"
+        },
+        "actions": {
+          "view": "Ver equipamiento",
+          "edit": "Editar equipamiento",
+          "delete": "Eliminar equipamiento"
+        },
+        "add": {
+          "title": "Agregar nuevo equipamiento",
+          "search_label": "Buscar equipo",
+          "search_placeholder": "Ej: Monster Power Rack",
+          "select_placeholder": "Seleccionar un equipo (Ej: Monster Power Rack)",
+          "serial_label": "Número de serie",
+          "serial_placeholder": "Ej: SN-ROG-123",
+          "notes_label": "Notas",
+          "notes_placeholder": "Ej: Equipo listo para usar",
+          "button": "Agregar"
+        },
+        "inventory_title": "Inventario de la sucursal",
+        "empty": "No hay equipamiento asignado a esta sucursal.",
+        "modal": {
+          "edit": "Editar equipamiento",
+          "view": "Ver equipamiento",
+          "loading": "Cargando...",
+          "last_maintenance": "Último mantenimiento",
+          "notes": "Notas",
+          "status": "Estado",
+          "status_placeholder": "Seleccionar estado",
+          "save": "Guardar"
+        }
+      },
+      "instructors": {
+        "error_loading": "No se pudieron cargar los instructores",
+        "already_assigned": "El instructor ya está asignado",
+        "success_added_pending": "Instructor agregado (pendiente de guardar)",
+        "success_removed_local": "Instructor eliminado localmente",
+        "success_removed": "Instructor eliminado correctamente",
+        "error_removing": "No se pudo eliminar el instructor",
+        "no_changes": "No hay cambios para guardar",
+        "success_save": "Cambios guardados correctamente",
+        "error_save": "No se pudieron guardar los cambios",
+        "add_label": "Agregar instructor",
+        "select_placeholder": "Selecciona un instructor",
+        "add_button": "Agregar",
+        "loading": "Cargando instructores...",
+        "empty": "No hay instructores asignados.",
+        "remove": "Eliminar",
+        "info_scroll": "Hay muchos instructores, usa el scroll para ver más."
+      },
+      "services": {
+        "success_load_catalog": "Servicios de la sucursal cargados correctamente",
+        "error_load_catalog": "No se pudieron cargar los servicios disponibles",
+        "error_load_branch": "No se pudieron cargar los servicios de la sucursal",
+        "success_added": "Servicio \"{name}\" agregado",
+        "success_removed": "Servicio \"{name}\" eliminado",
+        "error_removing": "No se pudo eliminar el servicio",
+        "no_new_services": "No hay servicios nuevos para guardar",
+        "success_save": "Servicios guardados correctamente",
+        "error_save": "Error al guardar los servicios",
+        "success_update": "Servicio \"{name}\" actualizado",
+        "error_update": "Error al actualizar el servicio",
+        "title": "Servicios de la sucursal",
+        "subtitle": "Administra los servicios disponibles y sus precios.",
+        "add": {
+          "title": "Agregar nuevo servicio",
+          "select_placeholder": "Selecciona un servicio",
+          "capacity": "Aforo",
+          "member_price": "Precio miembros",
+          "non_member_price": "Precio no miembros",
+          "visible": "Visible",
+          "button": "Agregar"
+        },
+        "assigned_title": "Servicios asignados",
+        "loading": "Cargando servicios...",
+        "empty": "No hay servicios asignados.",
+        "description": "Aforo: {capacity} | Miembros: ${memberPrice} | No miembros: ${nonMemberPrice} | Visible: {visible}",
+        "yes": "Sí",
+        "no": "No",
+        "modal": {
+          "view": "Ver servicio",
+          "edit": "Editar servicio",
+          "loading": "Cargando...",
+          "capacity": "Aforo máximo",
+          "member_price": "Precio para miembros",
+          "non_member_price": "Precio para no miembros",
+          "visible": "Visible",
+          "save": "Guardar"
+        }
+      }
+    },
+    "notifications": {
+      "success_title": "¡Sucursal Creada!",
+      "success_description": "La nueva sucursal ha sido registrada exitosamente en el sistema.",
+      "action_text": "Entendido",
+      "error_required": "Por favor completa los campos obligatorios: Nombre, Tax ID, País y Estado."
+    },
+    "validations": {
+      "name_required": "La Razón Social es obligatoria.",
+      "tax_id_required": "El ID Fiscal es obligatorio.",
+      "status_required": "El estado de sucursal es obligatorio.",
+      "address_required": "La Dirección Completa es obligatoria.",
+      "location_required": "Debe seleccionar la ubicación en el mapa.",
+      "country_required": "El País es obligatorio.",
+      "state_required": "El Estado es obligatorio.",
+      "manager_required": "Debe asignar un Gerente Responsable.",
+      "capacity_required": "La capacidad debe ser un número válido (> 0).",
+      "opening_required": "La hora de apertura es obligatoria",
+      "closing_required": "La hora de cierre es obligatoria",
+      "payment_method_required": "Debe seleccionar al menos un método de pago"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -751,6 +752,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -774,6 +776,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5163,7 +5166,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5253,8 +5255,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5523,6 +5524,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5533,6 +5535,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5630,6 +5633,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -6132,6 +6136,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6697,6 +6702,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7573,8 +7579,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7890,6 +7895,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7991,6 +7997,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8092,6 +8099,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9992,6 +10000,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10993,6 +11002,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11561,7 +11571,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12602,6 +12611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12628,7 +12638,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12650,6 +12659,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12679,7 +12689,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12695,7 +12704,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12706,7 +12714,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12719,8 +12726,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -12899,6 +12905,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12929,6 +12936,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12972,6 +12980,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
       "integrity": "sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14269,7 +14278,8 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -14395,6 +14405,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14691,6 +14702,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15458,6 +15470,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/[locale]/(dashboard)/branches/BranchesTable.tsx
+++ b/src/app/[locale]/(dashboard)/branches/BranchesTable.tsx
@@ -1,13 +1,7 @@
 "use client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import EyeIcon from "@heroicons/react/24/outline/EyeIcon";
-import PencilIcon from "@heroicons/react/24/outline/PencilIcon";
 import { useEffect, useState } from "react";
-import { Instructor } from "@/models/instructor";
-import { Service } from "@/models/service";
-import { Equipment } from "@/models/equipment";
-import { PaymentMethodUI } from "./page";
 import { Column, DataTable } from "@/components/ui/table/DataTable";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { PaginatedBranch } from "@vitalfit/sdk";
@@ -48,6 +42,8 @@ interface BranchRow {
   name: string;
 }
 
+import { useTranslations } from "next-intl";
+
 export default function BranchesTable({
   data,
   isLoading,
@@ -60,6 +56,7 @@ export default function BranchesTable({
   onPageSizeChange,
   onBranchDeleted,
 }: BranchesTableProps) {
+  const t = useTranslations("branches");
   const [inputFilters, setInputFilters] = useState<Record<string, string>>({});
 
   const [deleteRowId, setDeleteRowId] = useState<string | null>(null);
@@ -70,11 +67,11 @@ export default function BranchesTable({
   const router = useRouter();
 
   const handleView = (row: BranchRow) => {
-    router.push(`/branches/${row.branch_id}`);
+    router.replace(`/branches/${row.branch_id}`);
   };
 
   const handleEdit = (row: BranchRow) => {
-    router.push(`/branches/${row.branch_id}/edit`);
+    router.replace(`/branches/${row.branch_id}/edit`);
   };
 
   const confirmDelete = (row: BranchRow) => {
@@ -89,13 +86,13 @@ export default function BranchesTable({
     api.branch
       .delete(pendingRow.branch_id, token || "")
       .then(() => {
-        setDeleteSuccess(`Sucursal eliminada: ${pendingRow.name}`);
+        setDeleteSuccess(t("table.delete_dialog.success", { name: pendingRow.name }));
         if (typeof onBranchDeleted === "function") {
           onBranchDeleted();
         }
       })
       .catch((error) => {
-        setDeleteError("Error al eliminar la sucursal. Intenta nuevamente.");
+        setDeleteError(t("table.delete_dialog.error"));
         console.error("Error al eliminar (directo del SDK):", error);
       })
       .finally(() => {
@@ -107,35 +104,35 @@ export default function BranchesTable({
   const columns: Column<PaginatedBranch>[] = [
     {
       accessor: "name",
-      header: "Nombre",
+      header: t("table.columns.name"),
     },
-    { header: "taxId", accessor: "tax_id" },
+    { header: t("table.columns.tax_id"), accessor: "tax_id" },
     {
-      header: "Administrador",
+      header: t("table.columns.manager"),
       accessor: "manager_name",
       render: (_, row) => `${row.manager_name} ${row.manager_last_name}`,
     },
     {
-      header: "País",
+      header: t("table.columns.country"),
       accessor: "country_name",
     },
     {
       accessor: "status",
-      header: "Estado",
+      header: t("table.columns.status"),
       render: (value) => {
         const statusConfig = {
-          Active: { text: "Activa", color: "text-green-700 border-green-300" },
+          Active: { text: t("table.status.active"), color: "text-green-700 border-green-300" },
           Inactive: {
-            text: "Inactiva",
+            text: t("table.status.inactive"),
             color: "text-red-700 border-red-300",
           },
           Maintenance: {
-            text: "En mantenimiento",
+            text: t("table.status.maintenance"),
             color: "text-yellow-700 border-yellow-300",
           },
         };
         const config = statusConfig[value as keyof typeof statusConfig] ?? {
-          text: "Desconocido",
+          text: t("table.status.unknown"),
           color: "bg-gray-100 text-gray-700 border-gray-300",
         };
         return (
@@ -181,7 +178,7 @@ export default function BranchesTable({
         <div className="relative w-full sm:w-[250px]">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Buscar por nombre o RIF"
+            placeholder={t("table.placeholder")}
             className="pl-9"
             value={inputFilters.search || ""}
             onChange={(e) =>
@@ -196,12 +193,12 @@ export default function BranchesTable({
           }
         >
           <SelectTrigger className="w-full sm:w-[200px] border border-gray-300 rounded-md px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-            <SelectValue placeholder="Estatus" />
+            <SelectValue placeholder={t("table.filter_status")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="Active">Activa</SelectItem>
-            <SelectItem value="Inactive">Inactiva</SelectItem>
-            <SelectItem value="Maintenance">Mantenimiento</SelectItem>
+            <SelectItem value="Active">{t("table.status.active")}</SelectItem>
+            <SelectItem value="Inactive">{t("table.status.inactive")}</SelectItem>
+            <SelectItem value="Maintenance">{t("table.status.maintenance")}</SelectItem>
           </SelectContent>
         </Select>
 
@@ -216,24 +213,23 @@ export default function BranchesTable({
               setInputFilters({});
             }}
           >
-            Limpiar filtros
+            {t("table.clear_filters")}
           </Button>
         ) : null}
 
         <div className="flex items-center gap-4">
           <Button variant="outline">
             <Download className="mr-2 h-4 w-4" />
-            Download CSV
+            {t("table.download")}
           </Button>
         </div>
       </div>
 
       {deleteRowId && pendingRow && (
         <Alert className="mt-2 w-full max-w-md">
-          <AlertTitle className="text-black">Confirmar Eliminación</AlertTitle>
+          <AlertTitle className="text-black">{t("table.delete_dialog.title")}</AlertTitle>
           <AlertDescription className="text-gray-900">
-            ¿Estás seguro de que deseas eliminar este servicio? Esta acción no
-            se puede deshacer.
+            {t("table.delete_dialog.description")}
           </AlertDescription>
           <div className="flex justify-end gap-2 mt-4">
             <Button
@@ -244,7 +240,7 @@ export default function BranchesTable({
                 setPendingRow(null);
               }}
             >
-              Cancelar
+              {t("table.delete_dialog.cancel")}
             </Button>
             <Button
               variant="destructive"
@@ -252,7 +248,7 @@ export default function BranchesTable({
               onClick={handleDelete}
             >
               <Trash2 className="h-4 w-4 text-white" />
-              Eliminar
+              {t("table.delete_dialog.confirm")}
             </Button>
           </div>
         </Alert>
@@ -260,14 +256,14 @@ export default function BranchesTable({
 
       {deleteSuccess && (
         <Alert className="w-full max-w-md border-green-300 bg-white text-green-800 mb-4">
-          <AlertTitle>Eliminación exitosa</AlertTitle>
+          <AlertTitle>{t("table.delete_dialog.success_title")}</AlertTitle>
           <AlertDescription>{deleteSuccess}</AlertDescription>
         </Alert>
       )}
 
       {deleteError && (
         <Alert className="w-full max-w-md border-red-300 bg-white text-red-800 mb-4">
-          <AlertTitle>Error</AlertTitle>
+          <AlertTitle>{t("table.delete_dialog.error_title")}</AlertTitle>
           <AlertDescription>{deleteError}</AlertDescription>
         </Alert>
       )}
@@ -284,14 +280,14 @@ export default function BranchesTable({
         actions={(row) => (
           <RowActions
             actions={[
-              { label: "Ver", icon: Eye, onClick: () => handleView(row) },
+              { label: t("table.actions.view"), icon: Eye, onClick: () => handleView(row) },
               {
-                label: "Modificar",
+                label: t("table.actions.edit"),
                 icon: Pencil,
                 onClick: () => handleEdit(row),
               },
               {
-                label: "Eliminar",
+                label: t("table.actions.delete"),
                 icon: Trash2,
                 onClick: () => confirmDelete(row),
                 variant: "danger",

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchBasicDataPanel.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchBasicDataPanel.tsx
@@ -94,14 +94,23 @@ const transformDataForAPI = (data: BranchDetails): UpdateBranchRequest => {
   };
 };
 
+import { useTranslations } from "next-intl";
+
 export default function BranchBasicDataPanel({
   mode = "edit",
   formData,
   setFormData,
 }: BasicDataPanelProps) {
+  const t = useTranslations("branches");
   const [loading, setLoading] = useState(false);
   const isViewMode = mode === "view";
   const { token } = useAuth();
+
+  const statusOptions: { label: string; value: BranchDetails["status"] }[] = [
+    { label: t("table.status.active"), value: "Active" },
+    { label: t("table.status.inactive"), value: "Inactive" },
+    { label: t("table.status.maintenance"), value: "Maintenance" },
+  ];
 
   const handleMapSelect = (data: MapSelectData) => {
     setFormData((prev) => ({
@@ -137,10 +146,10 @@ export default function BranchBasicDataPanel({
     try {
       const payload = transformDataForAPI(formData);
       await api.branch.updateBranch(formData.branch_id, payload, token || "");
-      toast.success("Sucursal actualizada correctamente");
+      toast.success(t("details.basic.success_update"));
     } catch (err) {
       console.error(err);
-      toast.error("Error actualizando sucursal");
+      toast.error(t("details.basic.error_update"));
     } finally {
       setLoading(false);
     }
@@ -150,16 +159,16 @@ export default function BranchBasicDataPanel({
     <div className="space-y-10">
       <section>
         <h2 className="text-xl font-semibold text-gray-900">
-          Información básica
+          {t("details.basic.title")}
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          Datos legales y generales de la sucursal
+          {t("details.basic.subtitle")}
         </p>
 
         <form className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5">
           <InputField
             id="name"
-            label="Razón social"
+            label={t("details.basic.name")}
             value={formData.name ?? ""}
             onChange={(e) =>
               setFormData((prev) => ({ ...prev, name: e.target.value }))
@@ -169,7 +178,7 @@ export default function BranchBasicDataPanel({
 
           <InputField
             id="taxId"
-            label="RIF"
+            label={t("details.basic.tax_id")}
             value={formData.tax_id ?? ""}
             onChange={(e) =>
               setFormData((prev) => ({ ...prev, tax_id: e.target.value }))
@@ -179,7 +188,7 @@ export default function BranchBasicDataPanel({
 
           <InputField
             id="phone"
-            label="Teléfono"
+            label={t("details.basic.phone")}
             value={formData.phone ?? ""}
             onChange={(e) =>
               setFormData((prev) => ({ ...prev, phone: e.target.value }))
@@ -189,7 +198,7 @@ export default function BranchBasicDataPanel({
 
           <InputField
             id="maxCapacity"
-            label="Capacidad máxima"
+            label={t("details.basic.capacity")}
             type="number"
             value={formData.max_capacity ?? ""}
             onChange={(e) =>
@@ -206,7 +215,7 @@ export default function BranchBasicDataPanel({
               htmlFor="status"
               className="block text-sm font-medium text-gray-700"
             >
-              Estado de la sucursal
+              {t("details.basic.status")}
             </label>
             <Select
               value={formData.status ?? ""}
@@ -219,7 +228,7 @@ export default function BranchBasicDataPanel({
               disabled={isViewMode}
             >
               <SelectTrigger id="status">
-                <SelectValue placeholder="Selecciona un estado" />
+                <SelectValue placeholder={t("details.basic.status_placeholder")} />
               </SelectTrigger>
               <SelectContent>
                 {statusOptions.map((option) => (
@@ -234,25 +243,24 @@ export default function BranchBasicDataPanel({
         <Alert variant="default" className="mt-6">
           <InformationCircleIcon className="h-4 w-4" />
           <AlertDescription>
-            Estos datos deben corresponder con la documentación legal de la
-            sucursal.
+            {t("details.basic.hint")}
           </AlertDescription>
         </Alert>
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">Ubicación</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">{t("details.basic.location_title")}</h2>
         <p className="text-sm text-gray-600 mb-4">
-          Visualizando la ubicación de la sucursal
+          {t("details.basic.location_subtitle")}
         </p>
 
         <div className="grid grid-cols-6 gap-4">
           <div className="col-span-6">
             <InputField
-              label="Dirección Completa*"
+              label={t("create.form.location.address")}
               id="address"
               name="address"
-              placeholder="Av. Principal, Edificio Centro..."
+              placeholder={t("create.form.location.address_placeholder")}
               value={formData.address ?? ""}
               onChange={(e) =>
                 setFormData((prev) => ({ ...prev, address: e.target.value }))
@@ -262,11 +270,11 @@ export default function BranchBasicDataPanel({
           </div>
           <div className="col-span-6 md:col-span-3">
             <InputField
-              label="Estado"
+              label={t("create.form.location.state")}
               id="state"
               name="state"
               value={formData.state ?? ""}
-              placeholder="Se rellena con el mapa"
+              placeholder={t("create.form.location.state")}
               readOnly={isViewMode || !formData.state}
               className={isViewMode ? "bg-gray-100" : ""}
               onChange={(e) =>
@@ -277,11 +285,11 @@ export default function BranchBasicDataPanel({
 
           <div className="col-span-6 md:col-span-3">
             <InputField
-              label="País"
+              label={t("create.form.location.country")}
               id="country"
               name="country"
               value={formData.country ?? ""}
-              placeholder="Se rellena con el mapa"
+              placeholder={t("create.form.location.country")}
               readOnly={isViewMode || !formData.country}
               className={isViewMode ? "bg-gray-100" : ""}
               onChange={(e) =>
@@ -293,13 +301,13 @@ export default function BranchBasicDataPanel({
           <div className="col-span-6 flex items-center gap-2 mt-4">
             <MapPin className="w-4 h-4 text-gray-700" />
             <span className="text-sm font-medium text-gray-700">
-              Coordenadas GPS
+              {t("create.form.location.gps_coords")}
             </span>
           </div>
 
           <div className="col-span-6 md:col-span-3">
             <InputField
-              label="Latitud"
+              label={t("create.form.location.latitude")}
               id="latitude"
               name="latitude"
               readOnly
@@ -310,7 +318,7 @@ export default function BranchBasicDataPanel({
 
           <div className="col-span-6 md:col-span-3">
             <InputField
-              label="Longitud"
+              label={t("create.form.location.longitude")}
               id="longitude"
               name="longitude"
               readOnly
@@ -322,7 +330,7 @@ export default function BranchBasicDataPanel({
 
         <div className="mt-6">
           <h3 className="text-sm font-medium text-gray-700 mb-1 block">
-            Posición en el mapa
+            {t("details.basic.map_title")}
           </h3>
           <MapboxPicker
             lat={formData.latitude ? String(formData.latitude) : "0"}
@@ -335,7 +343,7 @@ export default function BranchBasicDataPanel({
       {/* Horarios */}
       <section>
         <h2 className="text-lg font-semibold text-gray-900 mb-1">
-          Horarios de operación
+          {t("details.basic.schedule_title")}
         </h2>
         <BranchSchedule
           schedule={formData.operating_hours || []}
@@ -346,7 +354,7 @@ export default function BranchBasicDataPanel({
 
       {!isViewMode && (
         <Button onClick={handleSaveChanges} disabled={loading}>
-          {loading ? "Guardando..." : "Guardar cambios"}
+          {loading ? t("create.form.buttons.saving") : t("create.form.buttons.save")}
         </Button>
       )}
     </div>

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchEquipmentPanel.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchEquipmentPanel.tsx
@@ -29,10 +29,13 @@ interface BranchEquipmentPanelProps {
   mode?: "view" | "edit";
 }
 
+import { useTranslations } from "next-intl";
+
 const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
   branchId,
   mode = "edit",
 }) => {
+  const t = useTranslations("branches");
   const { token } = useAuth();
   const isDisabled = mode === "view";
 
@@ -70,13 +73,13 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
         setAllEquipment(res.data);
       } catch (err) {
         console.error(err);
-        toast.error("Error cargando equipos");
+        toast.error(t("details.equipment.error_loading_catalog"));
       } finally {
         setLoading(false);
       }
     };
     fetchAllEquipment();
-  }, [token]);
+  }, [token, t]);
 
   const fetchInventory = async () => {
     if (!token) {
@@ -88,7 +91,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       setCurrentInventory(res.data);
     } catch (err) {
       console.error(err);
-      toast.error("Error cargando inventario");
+      toast.error(t("details.equipment.error_loading_inventory"));
     } finally {
       setLoading(false);
     }
@@ -100,7 +103,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
 
   const handleAddEquipment = () => {
     if (!selectedEquipmentId) {
-      toast.error("Debes seleccionar un equipo antes de agregarlo");
+      toast.error(t("details.equipment.select_before_adding"));
       return;
     }
 
@@ -124,7 +127,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       const errorMessages = validation.error.issues
         .map((e) => e.message)
         .join(", ");
-      toast.error(`Error al agregar equipo: ${errorMessages}`);
+      toast.error(t("details.equipment.error_adding", { errors: errorMessages }));
       return;
     }
 
@@ -133,7 +136,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
     setSerialNumber("");
     setNotes("");
     toast.success(
-      `Equipo "${newPending.name}" agregado al inventario pendiente`,
+      t("details.equipment.success_added_pending", { name: newPending.name }),
     );
   };
 
@@ -146,7 +149,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
         prev.filter((e) => e.inventory_id !== inventoryId),
       );
       toast.success(
-        `Equipo "${isPending.name}" eliminado del inventario pendiente`,
+        t("details.equipment.success_removed_pending", { name: isPending.name }),
       );
       return;
     }
@@ -163,12 +166,12 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       prev.filter((e) => e.inventory_id !== inventoryId),
     );
 
-    toast.success(`Equipo "${removed.name}" eliminado del inventario`);
+    toast.success(t("details.equipment.success_removed", { name: removed.name }));
   };
 
   const handleSaveChanges = async () => {
     if (!token) {
-      toast.error("Token inválido");
+      toast.error(t("details.equipment.error_invalid_token"));
       return;
     }
 
@@ -191,13 +194,13 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
         await api.equipment.removeBranchEquipment(branchId, invId, token);
       }
 
-      toast.success("Cambios guardados correctamente");
+      toast.success(t("details.equipment.success_save"));
       setPendingInventory([]);
       setRemovedInventoryIds([]);
       await fetchInventory();
     } catch (err) {
       console.error(err);
-      toast.error("Error guardando cambios");
+      toast.error(t("details.equipment.error_save"));
     } finally {
       setLoading(false);
     }
@@ -209,7 +212,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
     status: EquipmentStatus;
   }) => {
     if (!token || !equipmentToEdit) {
-      toast.error("Equipo inválido para actualizar");
+      toast.error(t("details.equipment.error_invalid_update"));
       return;
     }
 
@@ -223,7 +226,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       const errorMessages = validation.error.issues
         .map((e) => e.message)
         .join(", ");
-      toast.error(`Error al actualizar equipo: ${errorMessages}`);
+      toast.error(t("details.equipment.error_update", { errors: errorMessages }));
       return;
     }
 
@@ -245,24 +248,24 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       );
 
       toast.success(
-        `Equipo "${equipmentToEdit.name}" actualizado correctamente`,
+        t("details.equipment.success_update", { name: equipmentToEdit.name }),
       );
       setEditModalOpen(false);
       setEquipmentToEdit(null);
     } catch (err) {
       console.error(err);
-      toast.error("Error actualizando equipamiento");
+      toast.error(t("details.equipment.error_updating"));
     } finally {
       setLoading(false);
     }
   };
 
   const inventoryColumns: Column<BranchEquipmentInventory>[] = [
-    { header: "Nombre", accessor: "name" },
-    { header: "Serial", accessor: "serial_number" },
-    { header: "Estado", accessor: "status" },
-    { header: "Adquisición", accessor: "acquisition_date" },
-    { header: "Último mantenimiento", accessor: "last_maintenance_date" },
+    { header: t("details.equipment.table.name"), accessor: "name" },
+    { header: t("details.equipment.table.serial"), accessor: "serial_number" },
+    { header: t("details.equipment.table.status"), accessor: "status" },
+    { header: t("details.equipment.table.acquisition"), accessor: "acquisition_date" },
+    { header: t("details.equipment.table.last_maintenance"), accessor: "last_maintenance_date" },
   ];
 
   const handleEdit = (equipment: BranchEquipmentInventory) => {
@@ -281,7 +284,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
         size="icon"
         variant="outline"
         onClick={() => handleView(row)}
-        title="Ver equipamiento"
+        title={t("details.equipment.actions.view")}
       >
         <Eye size={16} />
       </Button>
@@ -291,7 +294,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
           size="icon"
           variant="outline"
           onClick={() => handleEdit(row)}
-          title="Editar equipamiento"
+          title={t("details.equipment.actions.edit")}
         >
           <Pencil size={16} />
         </Button>
@@ -302,7 +305,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
           size="icon"
           variant="outline"
           onClick={() => handleRemoveEquipment(row.inventory_id)}
-          title="Eliminar equipamiento"
+          title={t("details.equipment.actions.delete")}
         >
           <Trash2 size={16} />
         </Button>
@@ -322,15 +325,15 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
       {!isDisabled && (
         <div className="p-6 border rounded-xl bg-gray-50 shadow-sm">
           <h3 className="text-lg font-semibold text-gray-800 mb-4">
-            Agregar nuevo equipamiento
+            {t("details.equipment.add.title")}
           </h3>
 
           <div className="space-y-3">
             <label className="text-sm font-medium text-gray-700">
-              Buscar equipo
+              {t("details.equipment.add.search_label")}
             </label>
             <InputField
-              placeholder="Ej: Monster Power Rack"
+              placeholder={t("details.equipment.add.search_placeholder")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
@@ -339,7 +342,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
               onValueChange={setSelectedEquipmentId}
             >
               <SelectTrigger className="w-full">
-                <SelectValue placeholder="Seleccionar un equipo (Ej: Monster Power Rack)" />
+                <SelectValue placeholder={t("details.equipment.add.select_placeholder")} />
               </SelectTrigger>
               <SelectContent className="max-h-48 overflow-y-auto w-full">
                 {filteredEquipment.map((equipment) => (
@@ -356,17 +359,17 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
 
           <div className="flex flex-col sm:flex-row gap-4 mt-3">
             <InputField
-              label="Número de serie"
+              label={t("details.equipment.add.serial_label")}
               type="text"
-              placeholder="Ej: SN-ROG-123"
+              placeholder={t("details.equipment.add.serial_placeholder")}
               value={serialNumber}
               onChange={(e) => setSerialNumber(e.target.value)}
               className="flex-1"
             />
             <InputField
-              label="Notas"
+              label={t("details.equipment.add.notes_label")}
               type="text"
-              placeholder="Ej: Equipo listo para usar"
+              placeholder={t("details.equipment.add.notes_placeholder")}
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               className="flex-1"
@@ -380,7 +383,7 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
               onClick={handleAddEquipment}
               className="flex items-center"
             >
-              <Plus size={16} className="mr-2" /> Agregar
+              <Plus size={16} className="mr-2" /> {t("details.equipment.add.button")}
             </Button>
             <Button
               type="button"
@@ -390,16 +393,16 @@ const BranchEquipmentPanel: React.FC<BranchEquipmentPanelProps> = ({
                 removedInventoryIds.length === 0
               }
             >
-              {loading ? "Guardando..." : "Guardar cambios"}
+              {loading ? t("create.form.buttons.saving") : t("create.form.buttons.save")}
             </Button>
           </div>
         </div>
       )}
 
-      <h3 className="text-lg font-semibold">Inventario de la sucursal</h3>
+      <h3 className="text-lg font-semibold">{t("details.equipment.inventory_title")}</h3>
       {displayedInventory.length === 0 ? (
         <p className="text-sm text-gray-500">
-          No hay equipamiento asignado a esta sucursal.
+          {t("details.equipment.empty")}
         </p>
       ) : (
         <DataTable

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchFormContainer.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchFormContainer.tsx
@@ -18,10 +18,13 @@ interface BranchFormContainerProps {
   branch: BranchDetails;
 }
 
+import { useTranslations } from "next-intl";
+
 export default function BranchFormContainer({
   mode = "edit",
   branch,
 }: BranchFormContainerProps) {
+  const t = useTranslations("branches");
   const router = useRouter();
   const [formData, setFormData] = useState<BranchDetails>({ ...branch });
   const [allServicesFromApi, setAllServicesFromApi] = useState<
@@ -31,7 +34,7 @@ export default function BranchFormContainer({
   const tabs = [
     {
       value: "basic",
-      label: "General",
+      label: t("details.tabs.basic"),
       content: (
         <BranchBasicDataPanel
           mode={mode}
@@ -42,26 +45,26 @@ export default function BranchFormContainer({
     },
     {
       value: "payment",
-      label: "Métodos de pago",
+      label: t("details.tabs.payment"),
       content: (
         <BranchPaymentMethodPanel mode={mode} branchId={branch.branch_id} />
       ),
     },
     {
       value: "services",
-      label: "Servicios",
+      label: t("details.tabs.services"),
       content: <BranchServicePanel branchId={branch.branch_id} mode={mode} />,
     },
     {
       value: "instructors",
-      label: "Instructores",
+      label: t("details.tabs.instructors"),
       content: (
         <BranchInstructorPanel mode={mode} branchId={branch.branch_id} />
       ),
     },
     {
       value: "equipment",
-      label: "Equipamiento",
+      label: t("details.tabs.equipment"),
       content: <BranchEquipmentPanel mode={mode} branchId={branch.branch_id} />,
     },
   ];
@@ -71,9 +74,11 @@ export default function BranchFormContainer({
       <div className="flex justify-between items-center mb-4">
         <div>
           <h1 className="text-2xl font-bold">
-            {mode === "edit" ? "Modificar Sucursal" : "Detalles de sucursal"}
+            {mode === "edit" ? t("details.edit_title") : t("details.title")}
           </h1>
-          <p className="text-gray-500">Información de {formData.name}</p>
+          <p className="text-gray-500">
+            {t("details.info_of", { name: formData.name })}
+          </p>
         </div>
 
         <div className="flex gap-2">
@@ -81,7 +86,7 @@ export default function BranchFormContainer({
             <Button
               onClick={() => router.push(`/branches/${branch.branch_id}/edit`)}
             >
-              Modificar
+              {t("table.actions.edit")}
             </Button>
           )}
         </div>

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchInstructorsPanel.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchInstructorsPanel.tsx
@@ -20,10 +20,13 @@ interface BranchInstructorPanelProps {
   mode?: "view" | "edit";
 }
 
+import { useTranslations } from "next-intl";
+
 export default function BranchInstructorPanel({
   branchId,
   mode = "edit",
 }: BranchInstructorPanelProps) {
+  const t = useTranslations("branches");
   const { token } = useAuth();
   const isViewMode = mode === "view";
 
@@ -47,7 +50,7 @@ export default function BranchInstructorPanel({
   const fetchedRef = useRef(false);
 
   const fetchBranchInstructors = useCallback(async () => {
-    if (!token || !branchId) {return;}
+    if (!token || !branchId) { return; }
 
     try {
       setLoadingData(true);
@@ -67,15 +70,15 @@ export default function BranchInstructorPanel({
       setBranchInstructors(mapped);
     } catch (err) {
       console.error("Error cargando instructores:", err);
-      toast.error("No se pudieron cargar los instructores");
+      toast.error(t("details.instructors.error_loading"));
     } finally {
       setLoadingData(false);
     }
-  }, [token, branchId]);
+  }, [token, branchId, t]);
 
   const fetchAllInstructors = useCallback(
     async (page = 1) => {
-      if (!token || !hasMoreInstructors) {return;}
+      if (!token || !hasMoreInstructors) { return; }
 
       try {
         setLoadingData(true);
@@ -95,43 +98,43 @@ export default function BranchInstructorPanel({
         }
       } catch (err) {
         console.error("Error cargando instructores:", err);
-        toast.error("No se pudieron cargar los instructores");
+        toast.error(t("details.instructors.error_loading"));
       } finally {
         setLoadingData(false);
       }
     },
-    [token, hasMoreInstructors],
+    [token, hasMoreInstructors, t],
   );
 
   useEffect(() => {
-    if (fetchedRef.current) {return;}
+    if (fetchedRef.current) { return; }
     fetchedRef.current = true;
 
     fetchBranchInstructors();
 
-    if (!isViewMode) {fetchAllInstructors();}
+    if (!isViewMode) { fetchAllInstructors(); }
   }, [fetchBranchInstructors, fetchAllInstructors, isViewMode]);
 
   useEffect(() => {
     if (allInstructors.length > 50) {
-      toast.info("Hay muchos instructores, usa el scroll para ver más.");
+      toast.info(t("details.instructors.info_scroll"));
     }
-  }, [allInstructors]);
+  }, [allInstructors, t]);
 
   const handleAddInstructor = () => {
-    if (isViewMode || !selectedInstructorId) {return;}
+    if (isViewMode || !selectedInstructorId) { return; }
 
     if (
       branchInstructors.some((i) => i.instructorID === selectedInstructorId)
     ) {
-      toast.error("El instructor ya está asignado");
+      toast.error(t("details.instructors.already_assigned"));
       return;
     }
 
     const instructor = allInstructors.find(
       (i) => i.instructor_id === selectedInstructorId,
     );
-    if (!instructor) {return;}
+    if (!instructor) { return; }
 
     setBranchInstructors((prev) => [
       ...prev,
@@ -147,12 +150,12 @@ export default function BranchInstructorPanel({
     setDirty(true);
     setSelectedInstructorId(null);
 
-    toast.success("Instructor agregado (pendiente de guardar)");
+    toast.success(t("details.instructors.success_added_pending"));
   };
 
   const handleRemoveInstructor = async (instructorId: string) => {
-    if (isViewMode) {return;}
-    if (!token) {return;}
+    if (isViewMode) { return; }
+    if (!token) { return; }
 
     if (newInstructors.includes(instructorId)) {
       setBranchInstructors((prev) =>
@@ -160,7 +163,7 @@ export default function BranchInstructorPanel({
       );
       setNewInstructors((prev) => prev.filter((id) => id !== instructorId));
       setDirty(newInstructors.length > 1);
-      toast.success("Instructor eliminado localmente");
+      toast.success(t("details.instructors.success_removed_local"));
       return;
     }
 
@@ -176,10 +179,10 @@ export default function BranchInstructorPanel({
         prev.filter((i) => i.instructorID !== instructorId),
       );
 
-      toast.success("Instructor eliminado correctamente");
+      toast.success(t("details.instructors.success_removed"));
     } catch (err) {
       console.error("Error eliminando instructor:", err);
-      toast.error("No se pudo eliminar el instructor");
+      toast.error(t("details.instructors.error_removing"));
     } finally {
       setLoadingData(false);
     }
@@ -187,7 +190,7 @@ export default function BranchInstructorPanel({
 
   const handleSave = async () => {
     if (!token || !branchId || newInstructors.length === 0) {
-      toast.error("No hay cambios para guardar");
+      toast.error(t("details.instructors.no_changes"));
       return;
     }
 
@@ -198,10 +201,10 @@ export default function BranchInstructorPanel({
       await fetchBranchInstructors();
       setDirty(false);
 
-      toast.success("Cambios guardados correctamente");
+      toast.success(t("details.instructors.success_save"));
     } catch (err) {
       console.error("Error guardando cambios:", err);
-      toast.error("No se pudieron guardar los cambios");
+      toast.error(t("details.instructors.error_save"));
     } finally {
       setIsSaving(false);
     }
@@ -213,7 +216,7 @@ export default function BranchInstructorPanel({
         <div className="flex flex-col sm:flex-row gap-4 items-end">
           <div className="flex-grow">
             <label className="text-sm font-medium text-gray-700 mb-1 block">
-              Agregar instructor
+              {t("details.instructors.add_label")}
             </label>
 
             <Select
@@ -221,7 +224,7 @@ export default function BranchInstructorPanel({
               onValueChange={setSelectedInstructorId}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Selecciona un instructor" />
+                <SelectValue placeholder={t("details.instructors.select_placeholder")} />
               </SelectTrigger>
 
               <SelectContent
@@ -229,7 +232,7 @@ export default function BranchInstructorPanel({
                   const target = e.target as HTMLElement;
                   if (
                     target.scrollTop + target.clientHeight >=
-                      target.scrollHeight - 10 &&
+                    target.scrollHeight - 10 &&
                     hasMoreInstructors
                   ) {
                     const nextPage = currentPage + 1;
@@ -255,7 +258,7 @@ export default function BranchInstructorPanel({
             onClick={handleAddInstructor}
             disabled={!selectedInstructorId || loadingData || isSaving}
           >
-            Agregar
+            {t("details.instructors.add_button")}
           </Button>
 
           <Button
@@ -263,17 +266,17 @@ export default function BranchInstructorPanel({
             onClick={handleSave}
             disabled={!dirty || isSaving}
           >
-            {isSaving ? "Guardando..." : "Guardar cambios"}
+            {isSaving ? t("create.form.buttons.saving") : t("create.form.buttons.save")}
           </Button>
         </div>
       )}
 
       <div className="space-y-2">
         {loadingData ? (
-          <p className="text-sm text-gray-500">Cargando instructores...</p>
+          <p className="text-sm text-gray-500">{t("details.instructors.loading")}</p>
         ) : branchInstructors.length === 0 ? (
           <p className="text-sm text-gray-500">
-            No hay instructores asignados.
+            {t("details.instructors.empty")}
           </p>
         ) : (
           branchInstructors.map((instr) => (
@@ -294,7 +297,7 @@ export default function BranchInstructorPanel({
                     className="text-sm text-red-500 hover:underline"
                     onClick={() => handleRemoveInstructor(instr.instructorID)}
                   >
-                    Eliminar
+                    {t("details.instructors.remove")}
                   </button>
                 ) : undefined
               }

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchPaymentMethodsPanel.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchPaymentMethodsPanel.tsx
@@ -20,10 +20,13 @@ interface BranchPaymentMethodPanelProps {
   mode?: "edit" | "view";
 }
 
+import { useTranslations } from "next-intl";
+
 export default function BranchPaymentMethodPanel({
   branchId,
   mode = "edit",
 }: BranchPaymentMethodPanelProps) {
+  const t = useTranslations("branches");
   const { token } = useAuth();
 
   const [allPaymentMethods, setAllPaymentMethods] = useState<PaymentMethod[]>(
@@ -48,7 +51,7 @@ export default function BranchPaymentMethodPanel({
         setAllPaymentMethods(res.data || []);
       } catch (err) {
         console.error(err);
-        toast.error("No se pudieron cargar los métodos de pago disponibles");
+        toast.error(t("details.payment_methods.error_load"));
       } finally {
         setLoading(false);
       }
@@ -71,10 +74,10 @@ export default function BranchPaymentMethodPanel({
         );
         setSelectedMethods(res.data || []);
         setDirty(false);
-        toast.success("Métodos de pago de la sucursal cargados correctamente");
+        toast.success(t("details.payment_methods.success_load"));
       } catch (err) {
         console.error(err);
-        toast.error("No se pudieron cargar los métodos de pago de la sucursal");
+        toast.error(t("details.payment_methods.error_branch_load"));
       } finally {
         setLoading(false);
       }
@@ -104,7 +107,7 @@ export default function BranchPaymentMethodPanel({
     setSelectedMethods((prev) => [...prev, newMethod]);
     setSelectedId("");
     setDirty(true);
-    toast.success(`Método de pago "${method.name}" agregado`);
+    toast.success(t("details.payment_methods.success_add", { name: method.name }));
   };
 
   const handleRemove = async (id: string) => {
@@ -116,10 +119,10 @@ export default function BranchPaymentMethodPanel({
       await api.paymentMethod.removeBranchPaymentMethod(branchId, id, token);
       setSelectedMethods((prev) => prev.filter((m) => m.method_id !== id));
       setDirty(true);
-      toast.success("Método de pago eliminado correctamente");
+      toast.success(t("details.payment_methods.success_remove"));
     } catch (err) {
       console.error("Error eliminando método de pago:", err);
-      toast.error("No se pudo eliminar el método de pago");
+      toast.error(t("details.payment_methods.error_remove"));
     } finally {
       setLoading(false);
     }
@@ -137,9 +140,9 @@ export default function BranchPaymentMethodPanel({
       await toast.promise(
         api.paymentMethod.addBranchPaymentMethod(branchId, payload, token),
         {
-          loading: "Guardando métodos de pago...",
-          success: "Métodos de pago guardados correctamente",
-          error: "No se pudieron guardar los métodos de pago",
+          loading: t("details.payment_methods.saving"),
+          success: t("details.payment_methods.success_save"),
+          error: t("details.payment_methods.error_save"),
         },
       );
 
@@ -155,11 +158,10 @@ export default function BranchPaymentMethodPanel({
     <div className="space-y-6">
       <section>
         <h2 className="text-xl font-semibold text-gray-900">
-          Métodos de pago aceptados
+          {t("details.payment_methods.title")}
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          Selecciona los métodos de pago que estarán disponibles en esta
-          sucursal.
+          {t("details.payment_methods.subtitle")}
         </p>
       </section>
 
@@ -167,7 +169,7 @@ export default function BranchPaymentMethodPanel({
         <div className="flex gap-2 items-end">
           <Select value={selectedId} onValueChange={setSelectedId}>
             <SelectTrigger className="w-64">
-              <SelectValue placeholder="Selecciona un método..." />
+              <SelectValue placeholder={t("details.payment_methods.placeholder")} />
             </SelectTrigger>
             <SelectContent>
               {allPaymentMethods
@@ -183,7 +185,7 @@ export default function BranchPaymentMethodPanel({
             </SelectContent>
           </Select>
           <Button onClick={handleAddMethod} disabled={!selectedId}>
-            Agregar
+            {t("details.payment_methods.add")}
           </Button>
         </div>
       )}
@@ -191,7 +193,7 @@ export default function BranchPaymentMethodPanel({
       <div className="space-y-2">
         {selectedMethods.length === 0 ? (
           <p className="text-sm text-gray-500">
-            No hay métodos de pago seleccionados.
+            {t("details.payment_methods.empty")}
           </p>
         ) : (
           selectedMethods.map((method) => (
@@ -202,14 +204,14 @@ export default function BranchPaymentMethodPanel({
                 .map((n) => n[0])
                 .join("")}
               title={method.name}
-              description={`Tipo: ${method.type}`}
+              description={t("details.payment_methods.type", { type: method.type })}
               action={
                 mode === "edit" ? (
                   <button
                     className="text-sm text-red-500 hover:underline"
                     onClick={() => handleRemove(method.method_id)}
                   >
-                    Eliminar
+                    {t("details.payment_methods.remove")}
                   </button>
                 ) : null
               }
@@ -220,7 +222,7 @@ export default function BranchPaymentMethodPanel({
 
       {mode === "edit" && (
         <Button onClick={handleSave} disabled={!dirty || loading}>
-          {loading ? "Guardando..." : "Guardar cambios"}
+          {loading ? t("create.form.buttons.saving") : t("create.form.buttons.save")}
         </Button>
       )}
     </div>

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/BranchServicesPanel.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/BranchServicesPanel.tsx
@@ -30,8 +30,11 @@ interface BranchServicePanelProps {
   mode: "view" | "edit";
 }
 
+import { useTranslations } from "next-intl";
+
 const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
   const { branchId, mode = "edit" } = props;
+  const t = useTranslations("branches");
   const { token } = useAuth();
   const isDisabled = mode === "view";
 
@@ -65,15 +68,15 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
     const fetchServices = async () => {
       try {
         const response = await api.products.getServices(token, { page: 1 });
-        toast.success("Servicios de la sucursal cargados correctamente");
+        toast.success(t("details.services.success_load_catalog"));
         setAllServices(response.data || []);
       } catch (err) {
         console.error("Error cargando servicios:", err);
-        toast.error("No se pudieron cargar los servicios disponibles");
+        toast.error(t("details.services.error_load_catalog"));
       }
     };
     fetchServices();
-  }, [token]);
+  }, [token, t]);
 
   useEffect(() => {
     if (!token || !branchId) {
@@ -86,19 +89,19 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
         setServices(response.data || []);
       } catch (err) {
         console.error("Error cargando servicios de la sucursal:", err);
-        toast.error("No se pudieron cargar los servicios de la sucursal");
+        toast.error(t("details.services.error_load_branch"));
       } finally {
         setIsLoading(false);
       }
     };
     fetchBranchServices();
-  }, [token, branchId]);
+  }, [token, branchId, t]);
 
   const handleAddService = () => {
-    if (!selectedServiceId) {return;}
+    if (!selectedServiceId) { return; }
 
     const service = allServices.find((s) => s.service_id === selectedServiceId);
-    if (!service) {return;}
+    if (!service) { return; }
 
     const newService: CreateBranchServicePriceItem = {
       service_id: service.service_id,
@@ -131,7 +134,7 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
     setPriceNonMember(0);
     setIsVisible(true);
 
-    toast.success(`Servicio "${service.name}" agregado`);
+    toast.success(t("details.services.success_added", { name: service.name }));
   };
 
   const handleRemoveService = async (serviceId: string) => {
@@ -152,11 +155,11 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
       setServices((prev) => prev.filter((s) => s.service_id !== serviceId));
       setDirty(true);
       toast.success(
-        `Servicio "${removedService?.service_name ?? ""}" eliminado`,
+        t("details.services.success_removed", { name: removedService?.service_name ?? "" }),
       );
     } catch (err) {
       console.error("Error eliminando servicio:", err);
-      toast.error("No se pudo eliminar el servicio");
+      toast.error(t("details.services.error_removing"));
     } finally {
       setIsLoading(false);
     }
@@ -167,7 +170,7 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
       return;
     }
     if (newServices.length === 0) {
-      toast.error("No hay servicios nuevos para guardar");
+      toast.error(t("details.services.no_new_services"));
       return;
     }
 
@@ -179,10 +182,10 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
       setNewServices([]);
       setDirty(false);
 
-      toast.success("Servicios guardados correctamente");
+      toast.success(t("details.services.save_success"));
     } catch (err) {
       console.error("Error guardando servicios:", err);
-      toast.error("Error al guardar los servicios");
+      toast.error(t("details.services.save_error"));
     } finally {
       setLoading(false);
     }
@@ -216,10 +219,10 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
       setEditModalOpen(false);
       setServiceToEdit(null);
 
-      toast.success(`Servicio "${serviceToEdit.service_name}" actualizado`);
+      toast.success(t("details.services.success_update", { name: serviceToEdit.service_name ?? "" }));
     } catch (err) {
       console.error("Error actualizando servicio:", err);
-      toast.error("Error al actualizar el servicio");
+      toast.error(t("details.services.error_update"));
     }
   };
 
@@ -239,10 +242,10 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
     <div className="space-y-10">
       <section>
         <h2 className="text-xl font-semibold text-gray-900">
-          Servicios de la sucursal
+          {t("details.services.title")}
         </h2>
         <p className="mt-1 text-sm text-gray-600">
-          Administra los servicios disponibles y sus precios.
+          {t("details.services.subtitle")}
         </p>
       </section>
 
@@ -251,14 +254,14 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
           <div className="flex flex-col sm:flex-row flex-wrap gap-4 items-end">
             <div className="flex-grow min-w-[200px] space-y-1.5">
               <p className="text-sm font-medium text-gray-700">
-                Agregar nuevo servicio
+                {t("details.services.add.title")}
               </p>
               <Select
                 value={selectedServiceId ?? ""}
                 onValueChange={setSelectedServiceId}
               >
                 <SelectTrigger id="service-select">
-                  <SelectValue placeholder="Selecciona un servicio" />
+                  <SelectValue placeholder={t("details.services.add.select_placeholder")} />
                 </SelectTrigger>
                 <SelectContent>
                   {allServices
@@ -281,21 +284,21 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
             </div>
 
             <InputField
-              label="Aforo"
+              label={t("details.services.add.capacity")}
               type="number"
               min={0}
               value={aforo}
               onChange={(e) => setAforo(Number(e.target.value))}
             />
             <InputField
-              label="Precio miembros"
+              label={t("details.services.add.member_price")}
               type="number"
               min={0}
               value={priceMember}
               onChange={(e) => setPriceMember(Number(e.target.value))}
             />
             <InputField
-              label="Precio no miembros"
+              label={t("details.services.add.non_member_price")}
               type="number"
               min={0}
               value={priceNonMember}
@@ -309,7 +312,7 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
                 onChange={(e) => setIsVisible(e.target.checked)}
                 className="h-4 w-4"
               />
-              <label className="text-sm">Visible</label>
+              <label className="text-sm">{t("details.services.add.visible")}</label>
             </div>
 
             <Button
@@ -318,7 +321,7 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
               disabled={!selectedServiceId || aforo <= 0}
               onClick={handleAddService}
             >
-              <Plus size={16} className="mr-2" /> Agregar
+              <Plus size={16} className="mr-2" /> {t("details.services.add.button")}
             </Button>
           </div>
         </div>
@@ -326,21 +329,26 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
 
       <div>
         <h3 className="text-sm font-medium text-gray-800 mb-4">
-          Servicios asignados
+          {t("details.services.assigned_title")}
         </h3>
         {isLoading ? (
-          <p className="text-sm text-gray-500">Cargando servicios...</p>
+          <p className="text-sm text-gray-500">{t("details.services.loading")}</p>
         ) : services.length === 0 ? (
-          <p className="text-sm text-gray-500">No hay servicios asignados.</p>
+          <p className="text-sm text-gray-500">{t("details.services.empty")}</p>
         ) : (
           services.map((service) => (
             <EntityItem
               key={service.service_id}
               initials={getInitials(service.service_name ?? "??")}
               title={
-                service.service_name ?? `Servicio ID: ${service.service_id}`
+                service.service_name ?? `${t("catalog.services.id_prefix")}: ${service.service_id}`
               }
-              description={`Aforo: ${service.max_capacity} | Miembros: $${service.price_for_member} | No miembros: $${service.price_for_non_member} | Visible: ${service.is_visible ? "Sí" : "No"}`}
+              description={t("details.services.description", {
+                capacity: service.max_capacity,
+                memberPrice: service.price_for_member,
+                nonMemberPrice: service.price_for_non_member,
+                visible: service.is_visible ? t("details.services.yes") : t("details.services.no"),
+              })}
               action={
                 !isDisabled ? (
                   <div className="flex gap-2">
@@ -375,7 +383,7 @@ const BranchServicePanel = forwardRef((props: BranchServicePanelProps, ref) => {
 
       {!isDisabled && (
         <Button onClick={handleSave} disabled={!dirty || loading}>
-          {loading ? "Guardando..." : "Guardar cambios"}
+          {loading ? t("create.form.buttons.saving") : t("create.form.buttons.save")}
         </Button>
       )}
 

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/EditBranchEquipmentModal.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/EditBranchEquipmentModal.tsx
@@ -32,6 +32,8 @@ interface EditBranchEquipmentModalProps {
   mode?: "view" | "edit";
 }
 
+import { useTranslations } from "next-intl";
+
 export default function EditBranchEquipmentModal({
   open,
   onClose,
@@ -39,6 +41,7 @@ export default function EditBranchEquipmentModal({
   onSave,
   mode = "edit",
 }: EditBranchEquipmentModalProps) {
+  const t = useTranslations("branches");
   const isViewMode = mode === "view";
 
   const [lastMaintenanceDate, setLastMaintenanceDate] = useState("");
@@ -68,18 +71,22 @@ export default function EditBranchEquipmentModal({
       <DialogContent>
         <DialogHeader>
           <VisuallyHidden>
-            <DialogTitle>Editar equipamiento</DialogTitle>
+            <DialogTitle>
+              {isViewMode
+                ? t("details.equipment.modal.view")
+                : t("details.equipment.modal.edit")}
+            </DialogTitle>
           </VisuallyHidden>
         </DialogHeader>
 
         {!equipment ? (
-          <p className="text-sm text-gray-500">Cargando…</p>
+          <p className="text-sm text-gray-500">{t("details.equipment.modal.loading")}</p>
         ) : (
           <div className="space-y-4">
             <p className="text-lg font-semibold">{equipment.serial_number}</p>
 
             <InputField
-              label="Último mantenimiento"
+              label={t("details.equipment.modal.last_maintenance")}
               type="date"
               disabled={isViewMode}
               value={lastMaintenanceDate}
@@ -87,7 +94,7 @@ export default function EditBranchEquipmentModal({
             />
 
             <InputField
-              label="Notas"
+              label={t("details.equipment.modal.notes")}
               type="text"
               disabled={isViewMode}
               value={notes}
@@ -96,7 +103,7 @@ export default function EditBranchEquipmentModal({
 
             <div className="flex flex-col">
               <label className="text-sm font-medium text-gray-700 mb-1">
-                Estado
+                {t("details.equipment.modal.status")}
               </label>
               <Select
                 value={status}
@@ -104,7 +111,7 @@ export default function EditBranchEquipmentModal({
                 disabled={isViewMode}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Seleccionar estado" />
+                  <SelectValue placeholder={t("details.equipment.modal.status_placeholder")} />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="Available">Available</SelectItem>
@@ -118,7 +125,7 @@ export default function EditBranchEquipmentModal({
 
         {!isViewMode && (
           <DialogFooter>
-            <Button onClick={handleSave}>Guardar</Button>
+            <Button onClick={handleSave}>{t("details.equipment.modal.save")}</Button>
           </DialogFooter>
         )}
       </DialogContent>

--- a/src/app/[locale]/(dashboard)/branches/[id]/components/EditBranchServiceModal.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/components/EditBranchServiceModal.tsx
@@ -32,6 +32,8 @@ interface EditBranchServiceModalProps {
   mode?: "view" | "edit";
 }
 
+import { useTranslations } from "next-intl";
+
 export default function EditBranchServiceModal({
   open,
   onClose,
@@ -39,6 +41,7 @@ export default function EditBranchServiceModal({
   onSave,
   mode = "edit",
 }: EditBranchServiceModalProps) {
+  const t = useTranslations("branches");
   const isViewMode = mode === "view";
 
   const [maxCapacity, setMaxCapacity] = useState(0);
@@ -67,11 +70,11 @@ export default function EditBranchServiceModal({
         price_for_non_member: priceNonMember,
         is_visible: isVisible,
       });
-      toast.success(`Servicio "${service.service_name}" actualizado`);
+      toast.success(t("details.services.success_update", { name: service.service_name ?? "" }));
       onClose();
     } catch (err) {
       console.error(err);
-      toast.error(`Error actualizando "${service.service_name}"`);
+      toast.error(t("details.services.error_update", { name: service.service_name ?? "" }));
     }
   };
 
@@ -81,19 +84,21 @@ export default function EditBranchServiceModal({
         <DialogHeader>
           <VisuallyHidden>
             <DialogTitle>
-              {isViewMode ? "Ver servicio" : "Editar servicio"}
+              {isViewMode
+                ? t("details.services.modal.view")
+                : t("details.services.modal.edit")}
             </DialogTitle>
           </VisuallyHidden>
         </DialogHeader>
 
         {!service ? (
-          <p className="text-sm text-gray-500">Cargando…</p>
+          <p className="text-sm text-gray-500">{t("details.services.modal.loading")}</p>
         ) : (
           <div className="space-y-4">
             <p className="text-lg font-semibold">{service.service_name}</p>
 
             <InputField
-              label="Aforo máximo"
+              label={t("details.services.modal.capacity")}
               type="number"
               disabled={isViewMode}
               value={maxCapacity}
@@ -101,7 +106,7 @@ export default function EditBranchServiceModal({
             />
 
             <InputField
-              label="Precio para miembros"
+              label={t("details.services.modal.member_price")}
               type="number"
               disabled={isViewMode}
               value={priceMember}
@@ -109,7 +114,7 @@ export default function EditBranchServiceModal({
             />
 
             <InputField
-              label="Precio para no miembros"
+              label={t("details.services.modal.non_member_price")}
               type="number"
               disabled={isViewMode}
               value={priceNonMember}
@@ -123,14 +128,14 @@ export default function EditBranchServiceModal({
                 checked={isVisible}
                 onChange={(e) => setIsVisible(e.target.checked)}
               />
-              <label>Visible</label>
+              <label>{t("details.services.modal.visible")}</label>
             </div>
           </div>
         )}
 
         {!isViewMode && (
           <DialogFooter>
-            <Button onClick={handleSave}>Guardar</Button>
+            <Button onClick={handleSave}>{t("details.services.modal.save")}</Button>
           </DialogFooter>
         )}
       </DialogContent>

--- a/src/app/[locale]/(dashboard)/branches/[id]/edit/page.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/edit/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useAuth } from "@/context/AuthContext";
-// 1. Importa el CONTENEDOR, no el JSON
 import BranchFormContainer from "../components/BranchFormContainer";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/sdk-config";
 import { BranchDetails } from "@vitalfit/sdk";
 
+import { useTranslations } from "next-intl";
+
 export default function EditBranchPage() {
+  const t = useTranslations("branches");
   const params = useParams();
   const router = useRouter();
   const { token } = useAuth();
@@ -46,7 +48,7 @@ export default function EditBranchPage() {
           router.replace("/branches");
         } else {
           console.error("Error cargando sucursal:", err);
-          setError("No se pudo cargar la información de la sucursal.");
+          setError(t("details.error_loading"));
         }
       } finally {
         if (mounted) {
@@ -60,7 +62,7 @@ export default function EditBranchPage() {
   }, [id, token, router]);
 
   if (loading) {
-    return <div className="p-6">Cargando sucursal...</div>;
+    return <div className="p-6">{t("details.loading")}</div>;
   }
 
   if (error) {
@@ -68,7 +70,7 @@ export default function EditBranchPage() {
   }
 
   if (!branch) {
-    return <div className="p-6">No se encontró la sucursal.</div>;
+    return <div className="p-6">{t("details.not_found")}</div>;
   }
 
   return <BranchFormContainer mode="edit" branch={branch} />;

--- a/src/app/[locale]/(dashboard)/branches/[id]/page.tsx
+++ b/src/app/[locale]/(dashboard)/branches/[id]/page.tsx
@@ -7,7 +7,10 @@ import { useEffect, useState } from "react";
 import { api } from "@/lib/sdk-config";
 import { BranchDetails } from "@vitalfit/sdk";
 
+import { useTranslations } from "next-intl";
+
 export default function ViewBranchPage() {
+  const t = useTranslations("branches");
   const params = useParams();
   const router = useRouter();
   const { token } = useAuth();
@@ -47,7 +50,7 @@ export default function ViewBranchPage() {
           router.replace("/branches");
         } else {
           console.error("Error cargando sucursal:", err);
-          setError("No se pudo cargar la información de la sucursal.");
+          setError(t("details.error_loading"));
         }
       } finally {
         if (mounted) {
@@ -62,7 +65,7 @@ export default function ViewBranchPage() {
   }, [id, token, router]);
 
   if (loading) {
-    return <div className="p-6">Cargando sucursal...</div>;
+    return <div className="p-6">{t("details.loading")}</div>;
   }
 
   if (error) {

--- a/src/app/[locale]/(dashboard)/branches/new/CreateForm.tsx
+++ b/src/app/[locale]/(dashboard)/branches/new/CreateForm.tsx
@@ -28,12 +28,16 @@ interface BranchFromProps {
   allCities: City[];
 }
 
+import { useTranslations } from "next-intl";
+
 export default function CreateForm({
   allCountries,
   allStates,
   allCities,
 }: BranchFromProps) {
+  const t = useTranslations("branches");
   const router = useRouter();
+  // ... existing states ...
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [currentStep, setCurrentStep] = useState(1);
   const [allBranchAdmins, setAllBranchAdmins] = useState<User[]>([]);
@@ -60,10 +64,10 @@ export default function CreateForm({
   });
 
   const steps = [
-    { id: 1, name: "Información Básica", description: "Datos" },
-    { id: 2, name: "Ubicación", description: "Dirección" },
-    { id: 3, name: "Administración", description: "Gestión" },
-    { id: 4, name: "Confirmación", description: "Revisión" },
+    { id: 1, name: t("create.steps.basic.name"), description: t("create.steps.basic.description") },
+    { id: 2, name: t("create.steps.location.name"), description: t("create.steps.location.description") },
+    { id: 3, name: t("create.steps.admin.name"), description: t("create.steps.admin.description") },
+    { id: 4, name: t("create.steps.confirm.name"), description: t("create.steps.confirm.description") },
   ];
 
   useEffect(() => {
@@ -90,44 +94,43 @@ export default function CreateForm({
 
     if (stepToValidate === 1) {
       if (!formData.name?.trim()) {
-        errors.name = "La Razón Social es obligatoria.";
+        errors.name = t("validations.name_required");
         isValid = false;
       }
       if (!formData.taxId?.trim()) {
-        errors.taxId = "El ID Fiscal es obligatorio.";
+        errors.taxId = t("validations.tax_id_required");
         isValid = false;
       }
       if (!formData.status?.trim()) {
-        errors.status = "El estado de sucursal es obligatorio.";
+        errors.status = t("validations.status_required");
         isValid = false;
       }
     } else if (stepToValidate === 2) {
       if (!formData.address?.trim()) {
-        errors.address = "La Dirección Completa es obligatoria.";
+        errors.address = t("validations.address_required");
         isValid = false;
       }
       if (formData.latitude === 0 || formData.longitude === 0) {
-        errors.latitude = "Debe seleccionar la ubicación en el mapa.";
-        errors.longitude = "Debe seleccionar la ubicación en el mapa.";
+        errors.latitude = t("validations.location_required");
+        errors.longitude = t("validations.location_required");
         isValid = false;
       }
       if (!formData.countryId?.trim()) {
-        errors.countryId = "El País es obligatorio.";
+        errors.countryId = t("validations.country_required");
       }
       if (!formData.stateId?.trim()) {
-        errors.stateId = "El Estado es obligatorio.";
+        errors.stateId = t("validations.state_required");
       }
     } else if (stepToValidate === 3) {
       if (!formData.manager_id?.trim()) {
-        errors.manager_id = "Debe asignar un Gerente Responsable.";
+        errors.manager_id = t("validations.manager_required");
         isValid = false;
       }
       if (
         !formData.capacidadMiembros ||
         Number(formData.capacidadMiembros) <= 0
       ) {
-        errors.capacidadMiembros =
-          "La capacidad debe ser un número válido (> 0).";
+        errors.capacidadMiembros = t("validations.capacity_required");
         isValid = false;
       }
     }
@@ -250,16 +253,13 @@ export default function CreateForm({
       status: normalizedStatus,
     };
 
-    console.log("Payload enviado:", apiPayload);
     if (
       !apiPayload.name ||
       !apiPayload.tax_id ||
       !apiPayload.country ||
       !apiPayload.state
     ) {
-      alert(
-        "Por favor completa los campos obligatorios: Nombre, Tax ID, País y Estado.",
-      );
+      alert(t("notifications.error_required"));
       return;
     }
 
@@ -293,7 +293,7 @@ export default function CreateForm({
       <CardHeader className="sticky top-0 bg-white z-10 pt-6 pb-4 border-b">
         <div className="flex items-center justify-between w-full">
           <CardTitle className="text-2xl font-bold text-gray-800">
-            CREAR NUEVA SUCURSAL
+            {t("create.title")}
           </CardTitle>
           <div className="flex items-center gap-4">
             <Image
@@ -309,7 +309,7 @@ export default function CreateForm({
 
       <CardContent className="p-6 pt-4">
         <p className="text-sm text-gray-600 mb-6">
-          Complete los siguientes pasos para crear una nueva sucursal
+          {t("create.subtitle")}
         </p>
         <Wizard steps={steps} currentStep={currentStep} />
 
@@ -333,17 +333,17 @@ export default function CreateForm({
           className="flex items-center gap-2"
         >
           <ArrowLeftIcon className="w-4 h-4" />
-          Anterior
+          {t("create.form.buttons.back")}
         </Button>
         <Button
           onClick={currentStep === steps.length ? handleSubmit : handleNext}
           className="flex items-center gap-2"
         >
           {currentStep === steps.length ? (
-            "Crear Sucursal"
+            t("create.form.buttons.create")
           ) : (
             <>
-              Siguiente
+              {t("create.form.buttons.next")}
               <ArrowRightIcon className="w-4 h-4" />
             </>
           )}

--- a/src/app/[locale]/(dashboard)/branches/new/components/Step1.tsx
+++ b/src/app/[locale]/(dashboard)/branches/new/components/Step1.tsx
@@ -19,41 +19,44 @@ type StepProps = {
   formErrors?: Record<string, string>;
 };
 
+import { useTranslations } from "next-intl";
+
 export default function Step1({
   formData,
   handleChange,
   handleCustomChange,
   formErrors = {},
 }: StepProps) {
+  const t = useTranslations("branches");
   return (
     <div className="space-y-6">
       <h3 className="text-lg font-semibold text-gray-800 border-b pb-2">
-        Información Básica de la Sucursal
+        {t("create.form.basic_info.title")}
       </h3>
       <p className="text-sm text-gray-600 -mt-4">
-        Comience ingresando los datos fundamentales de la nueva sucursal.
+        {t("create.form.basic_info.subtitle")}
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <InputField
           id="name"
           name="name"
-          label="Razón Social *"
+          label={t("create.form.basic_info.name")}
           type="text"
           value={formData.name || ""}
           onChange={handleChange}
-          placeholder="Ej: FitnesPlaza"
+          placeholder={t("create.form.basic_info.name_placeholder")}
           error={formErrors["name"]}
         />
 
         <InputField
           id="taxId"
           name="taxId"
-          label="RIF *"
+          label={t("create.form.basic_info.tax_id")}
           type="text"
           value={formData.taxId || ""}
           onChange={handleChange}
-          placeholder="J-402456696-3"
+          placeholder={t("create.form.basic_info.tax_id_placeholder")}
           error={formErrors["taxId"]}
         />
       </div>
@@ -62,27 +65,27 @@ export default function Step1({
         <InputField
           id="phone"
           name="phone"
-          label="Teléfono"
+          label={t("create.form.basic_info.phone")}
           type="tel"
           value={formData.phone || ""}
           onChange={handleChange}
-          placeholder="Placeholder"
+          placeholder={t("create.form.basic_info.phone_placeholder")}
           error={formErrors["phone"]}
         />
 
         <div>
-          <label htmlFor="status">Estado de Sucursal *</label>
+          <label htmlFor="status">{t("create.form.basic_info.status")}</label>
           <Select
             value={formData.status || "active"}
             onValueChange={(value) => handleCustomChange("status", value)}
           >
             <SelectTrigger id="status" className="mt-1 w-full">
-              <SelectValue placeholder="Activa" />
+              <SelectValue placeholder={t("create.form.basic_info.status_placeholder")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="active">Activa</SelectItem>
-              <SelectItem value="inactive">Inactiva</SelectItem>
-              <SelectItem value="maintenance">Mantenimiento</SelectItem>
+              <SelectItem value="active">{t("table.status.active")}</SelectItem>
+              <SelectItem value="inactive">{t("table.status.inactive")}</SelectItem>
+              <SelectItem value="maintenance">{t("table.status.maintenance")}</SelectItem>
             </SelectContent>
           </Select>
           {formErrors["status"] && (
@@ -91,8 +94,8 @@ export default function Step1({
         </div>
       </div>
       <StepNotification
-        title="Próximos pasos"
-        description="En los siguientes pasos configuraremos la ubicación, contacto, horarios y empleados de la nueva sucursal."
+        title={t("create.form.basic_info.next_steps.title")}
+        description={t("create.form.basic_info.next_steps.description")}
       />
     </div>
   );

--- a/src/app/[locale]/(dashboard)/branches/new/components/Step2.tsx
+++ b/src/app/[locale]/(dashboard)/branches/new/components/Step2.tsx
@@ -21,12 +21,15 @@ type StepProps = {
   formErrors?: Record<string, string>;
 };
 
+import { useTranslations } from "next-intl";
+
 export default function Step2({
   formData,
   handleChange,
   handleCustomChange,
   formErrors = {},
 }: StepProps) {
+  const t = useTranslations("branches");
   const handleMapSelect = (data: {
     latitud: string;
     longitud: string;
@@ -42,8 +45,8 @@ export default function Step2({
     // Conversión a número
     const latNum = parseFloat(data.latitud);
     const lngNum = parseFloat(data.longitud);
-    if (!isNaN(latNum)) {handleCustomChange("latitude", latNum);}
-    if (!isNaN(lngNum)) {handleCustomChange("longitude", lngNum);}
+    if (!isNaN(latNum)) { handleCustomChange("latitude", latNum); }
+    if (!isNaN(lngNum)) { handleCustomChange("longitude", lngNum); }
 
     // IDs geográficos
     handleCustomChange("cityId", data.city);
@@ -60,10 +63,10 @@ export default function Step2({
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold text-gray-800 mb-1">
-          Ubicación y Contacto
+          {t("create.form.location.title")}
         </h3>
         <p className="text-sm text-gray-600">
-          Seleccione la ubicación exacta en el mapa o ingrese coordenadas
+          {t("create.form.location.subtitle")}
         </p>
       </div>
 
@@ -71,29 +74,30 @@ export default function Step2({
         {/* Dirección manual (ahora también se llena automáticamente) */}
         <div className="col-span-6">
           <InputField
-            label="Dirección Completa*"
+            label={t("create.form.location.address")}
             id="address"
             name="address"
             value={formData.address || ""}
             error={formErrors["address"]}
             onChange={handleChange}
-            placeholder="Ingrese la dirección manualmente o seleccione en el mapa"
+            placeholder={t("create.form.location.address_placeholder")}
             className="focus:ring-orange-500 focus:border-transparent"
           />
         </div>
 
-        {/* Ciudad / Estado / País */}
-        <InputField
-          label="Estado"
-          id="stateId"
-          name="stateId"
-          value={formData.stateId || ""}
-          readOnly
-          className="bg-gray-50 text-gray-700"
-        />
+        <div className="col-span-6 md:col-span-4">
+          <InputField
+            label={t("create.form.location.state")}
+            id="stateId"
+            name="stateId"
+            value={formData.stateId || ""}
+            readOnly
+            className="bg-gray-50 text-gray-700"
+          />
+        </div>
         <div className="col-span-6 md:col-span-2">
           <InputField
-            label="País"
+            label={t("create.form.location.country")}
             id="countryId"
             name="countryId"
             value={formData.countryId || ""}
@@ -105,13 +109,13 @@ export default function Step2({
         <div className="col-span-6 flex items-center gap-2 mt-4">
           <MapPin className="w-4 h-4 text-gray-700" />
           <span className="text-sm font-medium text-gray-700">
-            Coordenadas GPS
+            {t("create.form.location.gps_coords")}
           </span>
         </div>
 
         <div className="col-span-6 md:col-span-3">
           <InputField
-            label="Latitud"
+            label={t("create.form.location.latitude")}
             id="latitud"
             name="latitud"
             value={formData.latitud || ""}
@@ -122,7 +126,7 @@ export default function Step2({
 
         <div className="col-span-6 md:col-span-3">
           <InputField
-            label="Longitud"
+            label={t("create.form.location.longitude")}
             id="longitud"
             name="longitud"
             value={formData.longitud || ""}

--- a/src/app/[locale]/(dashboard)/branches/new/components/Step3.tsx
+++ b/src/app/[locale]/(dashboard)/branches/new/components/Step3.tsx
@@ -12,6 +12,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { User } from "@vitalfit/sdk";
 import { api } from "@/lib/sdk-config";
 
+import { useTranslations } from "next-intl";
+
 type StepProps = {
   formData: any;
   handleChange?: (
@@ -23,16 +25,6 @@ type StepProps = {
   formErrors?: Record<string, string>;
   allBranchAdmins?: User[];
 };
-
-const diasSemana = [
-  { id: "lunes", label: "Lunes" },
-  { id: "martes", label: "Martes" },
-  { id: "miercoles", label: "Miércoles" },
-  { id: "jueves", label: "Jueves" },
-  { id: "viernes", label: "Viernes" },
-  { id: "sabado", label: "Sábado" },
-  { id: "domingo", label: "Domingo" },
-];
 
 const horasApertura = [
   "6:00 AM",
@@ -64,6 +56,18 @@ export default function Step3({
   formErrors = {},
   allBranchAdmins = [],
 }: StepProps) {
+  const t = useTranslations("branches");
+
+  const diasSemana = [
+    { id: "lunes", label: t("create.form.admin.days.monday") },
+    { id: "martes", label: t("create.form.admin.days.tuesday") },
+    { id: "miercoles", label: t("create.form.admin.days.wednesday") },
+    { id: "jueves", label: t("create.form.admin.days.thursday") },
+    { id: "viernes", label: t("create.form.admin.days.friday") },
+    { id: "sabado", label: t("create.form.admin.days.saturday") },
+    { id: "domingo", label: t("create.form.admin.days.sunday") },
+  ];
+
   const handleHorarioChange = (dia: string, campo: string, valor: any) => {
     const horarios = formData.horarios || {};
     const horarioDia = horarios[dia] || {
@@ -96,11 +100,10 @@ export default function Step3({
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold text-gray-800 mb-1">
-          Administración
+          {t("create.form.admin.title")}
         </h3>
         <p className="text-sm text-gray-600">
-          Asigne el gerente responsable, defina la capacidad y configure los
-          horarios de operación para cada día de la semana
+          {t("create.form.admin.subtitle")}
         </p>
       </div>
 
@@ -108,14 +111,14 @@ export default function Step3({
         <div>
           <label className="block">
             <span className="text-sm font-medium text-gray-700">
-              Gerente Responsable *
+              {t("create.form.admin.manager")}
             </span>
             <Select
               value={formData.manager_id || ""}
               onValueChange={(value) => handleCustomChange("manager_id", value)}
             >
               <SelectTrigger className="mt-1 w-full">
-                <SelectValue placeholder="Seleccione un Gerente" />
+                <SelectValue placeholder={t("create.form.admin.manager_placeholder")} />
               </SelectTrigger>
               <SelectContent>
                 {allBranchAdmins.map((admin) => (
@@ -136,7 +139,7 @@ export default function Step3({
         <div>
           <label className="block">
             <span className="text-sm font-medium text-gray-700">
-              Capacidad de Miembros *
+              {t("create.form.admin.capacity")}
             </span>
             <input
               type="number"
@@ -144,13 +147,12 @@ export default function Step3({
               onChange={(e) =>
                 handleCustomChange("capacidadMiembros", e.target.value)
               }
-              placeholder="Ejemplo: 400"
+              placeholder={t("create.form.admin.capacity_placeholder")}
               min="1"
-              className={`mt-1 block w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 ${
-                formErrors?.["capacidadMiembros"]
+              className={`mt-1 block w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 ${formErrors?.["capacidadMiembros"]
                   ? "border-red-500 focus:ring-red-500"
                   : "border-gray-300 focus:ring-orange-500"
-              }`}
+                }`}
             />
             {formErrors?.["capacidadMiembros"] && (
               <p className="text-sm text-red-500 mt-1">
@@ -167,16 +169,16 @@ export default function Step3({
             <thead className="bg-gray-100">
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700 border-r border-gray-300">
-                  Día
+                  {t("create.form.admin.table.day")}
                 </th>
                 <th className="px-4 py-3 text-center text-sm font-semibold text-gray-700 border-r border-gray-300">
-                  Apertura
+                  {t("create.form.admin.table.opening")}
                 </th>
                 <th className="px-4 py-3 text-center text-sm font-semibold text-gray-700 border-r border-gray-300">
-                  Cierre
+                  {t("create.form.admin.table.closing")}
                 </th>
                 <th className="px-4 py-3 text-center text-sm font-semibold text-gray-700">
-                  Cerrado
+                  {t("create.form.admin.table.closed")}
                 </th>
               </tr>
             </thead>

--- a/src/app/[locale]/(dashboard)/branches/new/components/Step4.tsx
+++ b/src/app/[locale]/(dashboard)/branches/new/components/Step4.tsx
@@ -9,47 +9,35 @@ type StepProps = {
   formErrors?: Record<string, string>;
 };
 
-const defaultPolicies = [
-  { id: "p1", text: "Inscripción totalmente gratuita por tiempo limitado." },
-  {
-    id: "p2",
-    text: "Membresía flexible con un periodo mínimo de cancelación de solo 1 mes.",
-  },
-  {
-    id: "p3",
-    text: "Acceso a entrenador personal de planta sin costo adicional en cada horario.",
-  },
-  { id: "p4", text: "Clases especializadas para adultos +50 años." },
-  {
-    id: "p5",
-    text: "Beneficio 'Trae un amigo': 15 días de acceso gratuito para un acompañante.",
-  },
-  {
-    id: "p6",
-    text: "Diversidad de clases grupales incluidas: Baile, Boxeo, Yoga y más.",
-  },
-  { id: "p7", text: "Estacionamiento exclusivo/gratuito para miembros." },
-  {
-    id: "p8",
-    text: "Compromiso con la seguridad: Instalaciones seguras y monitoreadas para una experiencia libre de preocupaciones.",
-  },
-];
+import { useTranslations } from "next-intl";
 
 export default function Step4({ formData }: StepProps) {
+  const t = useTranslations("branches");
+
+  const defaultPolicies = [
+    { id: "p1", text: t("create.form.confirm.policies.p1") },
+    { id: "p2", text: t("create.form.confirm.policies.p2") },
+    { id: "p3", text: t("create.form.confirm.policies.p3") },
+    { id: "p4", text: t("create.form.confirm.policies.p4") },
+    { id: "p5", text: t("create.form.confirm.policies.p5") },
+    { id: "p6", text: t("create.form.confirm.policies.p6") },
+    { id: "p7", text: t("create.form.confirm.policies.p7") },
+    { id: "p8", text: t("create.form.confirm.policies.p8") },
+  ];
+
   return (
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold text-gray-800 mb-1">
-          Políticas Comerciales
+          {t("create.form.confirm.title")}
         </h3>
         <p className="text-sm text-gray-600 mb-4">
-          Seleccionas las políticas comerciales correspondientes para la
-          sucursal
+          {t("create.form.confirm.subtitle")}
         </p>
 
         <div className="space-y-4">
           <p className="text-sm font-semibold text-gray-700">
-            Selecciona dándole al check las políticas
+            {t("create.form.confirm.checkbox_label")}
           </p>
           {defaultPolicies.map((policy) => (
             <div key={policy.id} className="flex items-start space-x-3">
@@ -68,13 +56,13 @@ export default function Step4({ formData }: StepProps) {
         </div>
 
         <p className="text-xs text-gray-500 mt-4">
-          Estas políticas serán visibles para los miembros de esta sucursal
+          {t("create.form.confirm.footer_hint")}
         </p>
       </div>
 
       <StepNotification
-        title="Listo para crear"
-        description="Revise la información antes de confirmar. Una vez creada la sucursal, podrá modificar estos datos desde la gestión de sucursales."
+        title={t("create.form.confirm.next_steps.title")}
+        description={t("create.form.confirm.next_steps.description")}
       />
     </div>
   );

--- a/src/app/[locale]/(dashboard)/branches/page.tsx
+++ b/src/app/[locale]/(dashboard)/branches/page.tsx
@@ -7,7 +7,6 @@ import {
   BranchStatusCount,
   Pagination,
   PaymentMethod,
-  User,
 } from "@vitalfit/sdk";
 import {
   BanknotesIcon,
@@ -17,32 +16,13 @@ import {
   PlusIcon,
 } from "@heroicons/react/24/outline";
 import { useState, useEffect } from "react";
-import { Instructor } from "@/models/instructor";
-import { City, State, Country } from "@/models/location";
-import { Service } from "@/models/service";
-import { Equipment } from "@/models/equipment";
+import { Country } from "@/models/location";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { StatCard } from "@/components/ui/StatCard";
 import { GeneralAlertDialog } from "@/components/ui/GeneralAlertDialog";
 import { useAuth } from "@/context/AuthContext";
 import { useRouter, useSearchParams } from "next/navigation";
-
-const statCardsConfig: {
-  title: string;
-  valueKey: keyof BranchStatusCount | "Total";
-}[] = [
-  { title: "Total", valueKey: "Total" },
-  { title: "Activas", valueKey: "Active" },
-  { title: "Inactivas", valueKey: "Inactive" },
-  { title: "Mantenimiento", valueKey: "Maintenance" },
-];
-
-type StatsData = {
-  total: number;
-  active: number;
-  inactive: number;
-  maintenance: number;
-};
+import { useTranslations } from "next-intl";
 
 export type PaymentMethodUI = PaymentMethod & {
   icon?: React.ElementType;
@@ -72,9 +52,9 @@ function mapApiPaymentMethodsToUI(methods: PaymentMethod[]): PaymentMethodUI[] {
 }
 
 export default function HomeBranches() {
+  const t = useTranslations("branches");
   const { token } = useAuth();
   const router = useRouter();
-  const [isLoadingStatic, setIsLoadingStatic] = useState(true);
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [isLoadingBranches, setIsLoadingBranches] = useState(true);
@@ -104,6 +84,16 @@ export default function HomeBranches() {
       [key]: value,
     }));
   };
+
+  const statCardsConfig: {
+    title: string;
+    valueKey: keyof BranchStatusCount | "Total";
+  }[] = [
+      { title: t("stats.total"), valueKey: "Total" },
+      { title: t("stats.active"), valueKey: "Active" },
+      { title: t("stats.inactive"), valueKey: "Inactive" },
+      { title: t("stats.maintenance"), valueKey: "Maintenance" },
+    ];
 
   useEffect(() => {
     async function loadBranchesData() {
@@ -156,14 +146,14 @@ export default function HomeBranches() {
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
       <PageHeader
-        title="SUCURSALES"
+        title={t("title")}
         actionButton={
           <Button
             variant="default"
             onClick={() => router.push("/branches/new")}
           >
             <PlusIcon className="h-5 w-5" />
-            Crear Sucursal
+            {t("add_button")}
           </Button>
         }
       />
@@ -177,10 +167,10 @@ export default function HomeBranches() {
               <>
                 {card.valueKey === "Total"
                   ? statsData.Active +
-                    statsData.Inactive +
-                    statsData.Maintenance
+                  statsData.Inactive +
+                  statsData.Maintenance
                   : (statsData[card.valueKey] ?? 0)}
-                <span className="ml-1.5 text-base font-normal">SUCURSALES</span>
+                <span className="ml-1.5 text-base font-normal">{t("stats.unit")}</span>
               </>
             }
           />
@@ -204,9 +194,9 @@ export default function HomeBranches() {
         onOpenChange={setShowSuccessAlert}
         trigger={<span />}
         type="info"
-        title="¡Sucursal Creada!"
-        description="La nueva sucursal ha sido registrada exitosamente en el sistema."
-        actionText="Entendido"
+        title={t("notifications.success_title")}
+        description={t("notifications.success_description")}
+        actionText={t("notifications.action_text")}
       />
     </div>
   );

--- a/src/app/[locale]/(dashboard)/catalog/memberships/MembershipForm.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/MembershipForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/select";
 import { SelectValue } from "@radix-ui/react-select";
 import { MembershipType } from "@vitalfit/sdk";
+import { useTranslations } from "next-intl";
 
 type MembershipFormData = Omit<MembershipType, "duration_days" | "price"> & {
   duration_days: number | string;
@@ -31,6 +32,8 @@ export default function MembershipForm({
   disabled = false,
   errors = {},
 }: MembershipFormProps) {
+  const t = useTranslations("catalog.memberships");
+
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
@@ -40,12 +43,12 @@ export default function MembershipForm({
               htmlFor="nombre"
               className="block text-sm font-medium text-gray-700 mb-1 sm:text-base text-left"
             >
-              Nombre*
+              {t("form.labels.name")}
             </label>
             <Input
               id="nombre"
               name="nombre"
-              placeholder="Ej: Membresía Premium"
+              placeholder={t("form.placeholders.name")}
               disabled={disabled}
               value={formData.name}
               onChange={(e) => onChange("name", e.target.value)}
@@ -64,13 +67,13 @@ export default function MembershipForm({
             htmlFor="description"
             className="block text-sm font-medium text-gray-700 mb-1 sm:text-base text-left"
           >
-            Descripción*
+            {t("form.labels.description")}
           </label>
           <Textarea
             id="description"
             name="description"
             rows={3}
-            placeholder="Ej: Acceso ilimitado a todas las instalaciones"
+            placeholder={t("form.placeholders.description")}
             disabled={disabled}
             value={formData.description}
             onChange={(e) => onChange("description", e.target.value)}
@@ -88,7 +91,7 @@ export default function MembershipForm({
             htmlFor="duration_days"
             className="block text-sm font-medium text-gray-700 mb-1 sm:text-base text-left"
           >
-            Duración (Días)*
+            {t("form.labels.duration_days")}
           </label>
           <Input
             id="duration_days"
@@ -96,7 +99,7 @@ export default function MembershipForm({
             type="number"
             min="0"
             max="3650"
-            placeholder="Ej: 30"
+            placeholder={t("form.placeholders.duration_days")}
             disabled={disabled}
             value={formData.duration_days}
             onChange={(e) => onChange("duration_days", e.target.value)}
@@ -111,7 +114,7 @@ export default function MembershipForm({
             htmlFor="price"
             className="block text-sm font-medium text-gray-700 mb-1 sm:text-base text-left"
           >
-            Precio ($)*
+            {t("form.labels.price")}
           </label>
           <Input
             id="price"
@@ -120,7 +123,7 @@ export default function MembershipForm({
             step="0.01"
             min="0"
             max="999999.99"
-            placeholder="Ej: 99.99"
+            placeholder={t("form.placeholders.price")}
             disabled={disabled}
             value={formData.price}
             onChange={(e) => onChange("price", e.target.value)}
@@ -138,7 +141,7 @@ export default function MembershipForm({
             htmlFor="is_active"
             className="block text-sm font-medium text-gray-700 mb-1 sm:text-base text-left"
           >
-            Status
+            {t("form.labels.status")}
           </label>
           <Select
             name="is_active"
@@ -147,12 +150,12 @@ export default function MembershipForm({
           >
             <SelectTrigger className="w-full sm:w-[200px] border border-gray-300 rounded-md px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
               <SelectValue>
-                {formData.is_active ? "Activa" : "Inactiva"}
+                {formData.is_active ? t("table.status.active") : t("table.status.inactive")}
               </SelectValue>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="active">Activa</SelectItem>
-              <SelectItem value="inactive">Inactiva</SelectItem>
+              <SelectItem value="active">{t("table.status.active")}</SelectItem>
+              <SelectItem value="inactive">{t("table.status.inactive")}</SelectItem>
             </SelectContent>
           </Select>
           {errors.is_active && (

--- a/src/app/[locale]/(dashboard)/catalog/memberships/MembershipTable.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/MembershipTable.tsx
@@ -4,7 +4,6 @@ import { Column, DataTable } from "@/components/ui/table/DataTable";
 import { RowActions } from "@/components/ui/table/RowActions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/Input";
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import ArrowDownTray from "@heroicons/react/24/outline/ArrowDownTrayIcon";
 import MagnifyingGlassIcon from "@heroicons/react/24/outline/MagnifyingGlassIcon";
 import { Eye, Pencil, Trash2 } from "lucide-react";
@@ -13,8 +12,9 @@ import { useAuth } from "@/context/AuthContext";
 import { api } from "@/lib/sdk-config";
 import { useRouter } from "next/navigation";
 import { MembershipType } from "@vitalfit/sdk";
-import { Notification } from "@/components/ui/Notification";
 import { GeneralAlertDialog } from "@/components/ui/GeneralAlertDialog";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 interface MembershipTableProps {
   data: MembershipType[];
@@ -37,16 +37,13 @@ export default function MembershipTable({
   filters,
   onFilterChange,
 }: MembershipTableProps) {
+  const t = useTranslations("catalog.memberships");
   const [searchInput, setSearchInput] = useState(filters.search);
   const [deleteRowId, setDeleteRowId] = useState<string | null>(null);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const [pendingRow, setPendingRow] = useState<string | null>(null);
 
   const { token } = useAuth();
   const router = useRouter();
 
-  // 🔍 Manejo del campo de búsqueda
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (searchInput.trim() === "") {
@@ -61,51 +58,46 @@ export default function MembershipTable({
   }, [searchInput]);
 
   const handleView = (row: MembershipType) => {
-    router.push(`/memberships/${row.membership_type_id}`);
+    router.replace(`/catalog/memberships/${row.membership_type_id}`);
   };
 
   const handleEdit = (row: MembershipType) => {
-    router.push(`/memberships/${row.membership_type_id}/edit`);
+    router.replace(`/catalog/memberships/${row.membership_type_id}/edit`);
   };
 
   const handleDelete = async (membership: MembershipType) => {
     const membershipId = membership.membership_type_id;
 
     if (!token) {
-      setDeleteError("No estás autenticado para realizar esta acción.");
+      toast.error(t("notifications.delete_auth_error"));
       setDeleteRowId(null);
       return;
     }
 
-    setPendingRow(membershipId);
-    setDeleteError(null);
-
     try {
       await api.membership.deleteMembershipType(membershipId, token);
-      setShowSuccess(true);
+      toast.success(t("notifications.delete_success"));
       onReload();
-      setTimeout(() => setShowSuccess(false), 2000);
     } catch (error) {
       console.error("Error al eliminar la membresía:", error);
-      setDeleteError("Error al eliminar la membresía. Intenta nuevamente.");
+      toast.error(t("notifications.delete_error"));
     } finally {
       setDeleteRowId(null);
-      setPendingRow(null);
     }
   };
 
   const columns: Column<MembershipType>[] = [
-    { header: "Nombre", accessor: "name" },
-    { header: "Descripción", accessor: "description" },
-    { header: "Duración (días)", accessor: "duration_days" },
-    { header: "Precio", accessor: "price" },
+    { header: t("table.columns.name"), accessor: "name" },
+    { header: t("table.columns.description"), accessor: "description" },
+    { header: t("table.columns.duration"), accessor: "duration_days" },
+    { header: t("table.columns.price"), accessor: "price" },
     {
-      header: "Status",
+      header: t("table.columns.status"),
       accessor: "is_active",
       render: (value) => {
         const config = value
-          ? { text: "Activa", color: "text-green-700 border-green-300" }
-          : { text: "Inactiva", color: "text-yellow-700 border-yellow-300" };
+          ? { text: t("table.status.active"), color: "text-green-700 border-green-300" }
+          : { text: t("table.status.inactive"), color: "text-yellow-700 border-yellow-300" };
         return (
           <Badge variant="outline" className={`border ${config.color}`}>
             {config.text}
@@ -118,11 +110,10 @@ export default function MembershipTable({
   return (
     <>
       <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
-        {/* 🔍 Campo de búsqueda */}
         <div className="relative w-full sm:w-[250px]">
           <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Buscar membresía por nombre"
+            placeholder={t("table.placeholder")}
             className="pl-9"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
@@ -132,7 +123,7 @@ export default function MembershipTable({
         <div className="flex items-center gap-4">
           <Button variant="outline">
             <ArrowDownTray className="mr-2 h-4 w-4" />
-            Descargar
+            {t("table.download")}
           </Button>
         </div>
       </div>
@@ -141,6 +132,8 @@ export default function MembershipTable({
         key={`page-${page}-${data.length}`}
         columns={columns}
         data={data}
+        page={page}
+        pageSize={pageSize}
         onPageChange={onPageChange}
         totalPages={totalPages}
         rowIdKey="membership_type_id"
@@ -149,17 +142,17 @@ export default function MembershipTable({
             <RowActions
               actions={[
                 {
-                  label: "Ver Detalles",
+                  label: t("table.actions.view"),
                   icon: Eye,
                   onClick: () => handleView(row),
                 },
                 {
-                  label: "Modificar",
+                  label: t("table.actions.edit"),
                   icon: Pencil,
                   onClick: () => handleEdit(row),
                 },
                 {
-                  label: "Eliminar",
+                  label: t("table.actions.delete"),
                   icon: Trash2,
                   onClick: () => setDeleteRowId(row.membership_type_id),
                   variant: "danger",
@@ -172,10 +165,10 @@ export default function MembershipTable({
                 open={deleteRowId === row.membership_type_id}
                 onOpenChange={(open) => !open && setDeleteRowId(null)}
                 trigger={null}
-                title="Confirmar eliminación"
-                description="¿Estás seguro de que deseas eliminar esta membresía? Esta acción no se puede deshacer."
-                actionText="Eliminar"
-                cancelText="Cancelar"
+                title={t("table.delete_dialog.title")}
+                description={t("table.delete_dialog.description")}
+                actionText={t("table.delete_dialog.confirm")}
+                cancelText={t("table.delete_dialog.cancel")}
                 onAction={() => handleDelete(row)}
                 actionVariant="destructive"
               />
@@ -183,22 +176,6 @@ export default function MembershipTable({
           </div>
         )}
       />
-
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="Membresía eliminada correctamente"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
-
-      {deleteError && (
-        <Notification
-          variant="destructive"
-          description={deleteError}
-          onClose={() => setDeleteError(null)}
-        />
-      )}
     </>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/memberships/[id]/ViewMembership.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/[id]/ViewMembership.tsx
@@ -5,12 +5,14 @@ import MembershipForm from "../MembershipForm";
 import { MembershipType } from "@vitalfit/sdk";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 interface ViewMembershipProps {
   membership: MembershipType;
 }
 
 export default function ViewMembership({ membership }: ViewMembershipProps) {
+  const t = useTranslations("catalog.memberships");
   const router = useRouter();
   const id = membership.membership_type_id;
 
@@ -25,20 +27,20 @@ export default function ViewMembership({ membership }: ViewMembershipProps) {
 
   return (
     <div className="flex-1 space-y-6 p-8 pt-6 bg-white rounded shadow">
-      <PageHeader title="DETALLES DE MEMBRESÍA">
+      <PageHeader title={t("view.title")}>
         <Button
           variant="default"
           onClick={() => {
             router.push(`/memberships/${id}/edit`);
           }}
         >
-          Modificar
+          {t("view.button_edit")}
         </Button>
       </PageHeader>
 
       <MembershipForm
         formData={formData}
-        onChange={() => {}}
+        onChange={() => { }}
         mode="view"
         disabled
       />

--- a/src/app/[locale]/(dashboard)/catalog/memberships/[id]/edit/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/[id]/edit/page.tsx
@@ -6,13 +6,15 @@ import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/PageHeader";
 import MembershipForm from "../../MembershipForm";
 import { api } from "@/lib/sdk-config";
-import { Notification } from "@/components/ui/Notification";
 import { useAuth } from "@/context/AuthContext";
 import { MembershipType } from "@vitalfit/sdk";
 import { useRouter, useParams } from "next/navigation";
-import { membershipSchema } from "@/lib/validation/membershipSchema";
+import { useTranslations } from "next-intl";
+import { createMembershipSchema } from "@/lib/validation/membershipSchema";
+import { toast } from "sonner";
 
 export default function EditMembership() {
+  const t = useTranslations("catalog.memberships");
   const params = useParams();
   const router = useRouter();
   const { token } = useAuth();
@@ -25,12 +27,6 @@ export default function EditMembership() {
     Partial<Record<keyof MembershipType, string>>
   >({});
   const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [showServerError, setShowServerError] = useState({
-    visible: false,
-    message: "",
-  });
-  const [showConnectionError, setShowConnectionError] = useState(false);
 
   const [formData, setFormData] = useState<MembershipType>({
     membership_type_id: "",
@@ -43,7 +39,7 @@ export default function EditMembership() {
 
   useEffect(() => {
     if (!id) {
-      router.replace("/memberships");
+      router.replace("/catalog/memberships");
       return;
     }
     if (!token) {
@@ -70,10 +66,10 @@ export default function EditMembership() {
         }
         const status = err?.response?.status ?? err?.status ?? null;
         if (status === 404) {
-          router.replace("/memberships");
+          router.replace("/catalog/memberships");
         } else {
           console.error("Error cargando membresia:", err);
-          setError("No se pudo cargar la información de la membresía.");
+          setError(t("edit.error_load"));
         }
       } finally {
         if (mounted) {
@@ -109,7 +105,8 @@ export default function EditMembership() {
     formData: MembershipType,
     setErrors: (errors: Partial<Record<keyof MembershipType, string>>) => void,
   ): boolean => {
-    const result = membershipSchema.safeParse(formData);
+    const schema = createMembershipSchema((key) => t(`validations.${key.split('.').pop()}`));
+    const result = schema.safeParse(formData);
 
     if (!result.success) {
       const zodErrors = result.error.flatten().fieldErrors;
@@ -134,8 +131,6 @@ export default function EditMembership() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setShowServerError({ visible: false, message: "" });
-    setShowConnectionError(false);
 
     const isValid = validate(formData, setErrors);
     if (!isValid) {
@@ -144,10 +139,7 @@ export default function EditMembership() {
 
     const token = localStorage.getItem("access_token");
     if (!token || typeof token !== "string" || token.length < 10) {
-      setShowServerError({
-        visible: true,
-        message: "Token de autenticación no encontrado.",
-      });
+      toast.error(t("edit.error_auth"));
       return;
     }
 
@@ -166,14 +158,14 @@ export default function EditMembership() {
         payload,
         token,
       );
-      setShowSuccess(true);
-      setTimeout(() => router.push("/memberships"), 1500);
+      toast.success(t("edit.success"));
+      setTimeout(() => router.replace("/catalog/memberships"), 1500);
     } catch (err: any) {
       console.error("Error al actualizar membresia:", err);
       if (err?.response?.data?.error) {
-        setShowServerError({ visible: true, message: err.response.data.error });
+        toast.error(err.response.data.error);
       } else {
-        setShowConnectionError(true);
+        toast.error(t("edit.error_connection_description"));
       }
     } finally {
       setIsLoading(false);
@@ -183,19 +175,20 @@ export default function EditMembership() {
   return (
     <div className="flex-1 space-y-6 p-8 pt-6 bg-white rounded shadow">
       <form onSubmit={handleSubmit} className="space-y-2">
-        <PageHeader title="MODIFICAR MEMBRESÍA">
+        <PageHeader title={t("edit.title")}>
           <Button
+            type="button"
             variant="secondary"
-            onClick={() => router.push("/memberships")}
+            onClick={() => router.replace("/catalog/memberships")}
           >
-            Cancelar
+            {t("edit.button_cancel")}
           </Button>
           <Button type="submit" variant="default" disabled={isLoading}>
-            {isLoading ? "Guardando..." : "Guardar Cambios"}
+            {isLoading ? t("edit.button_saving") : t("edit.button_save")}
           </Button>
         </PageHeader>
         <p className="text-sm text-muted-foreground">
-          Modifica la información de la membresía {membership?.name}
+          {t("edit.subtitle", { name: membership?.name || "" })}
         </p>
 
         {!loading && (
@@ -207,30 +200,6 @@ export default function EditMembership() {
           />
         )}
       </form>
-
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="Membresía actualizado exitosamente!"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
-      {showConnectionError && (
-        <Notification
-          variant="destructive"
-          title="Error de conexión"
-          description="No se pudo conectar con el servidor. Intenta más tarde."
-          onClose={() => setShowConnectionError(false)}
-        />
-      )}
-      {showServerError.visible && (
-        <Notification
-          variant="destructive"
-          title="Error al actualizar membresia"
-          description={showServerError.message}
-          onClose={() => setShowServerError({ visible: false, message: "" })}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/memberships/[id]/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/[id]/page.tsx
@@ -6,8 +6,10 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/sdk-config";
 import { MembershipType, DataResponse } from "@vitalfit/sdk";
+import { useTranslations } from "next-intl";
 
 export default function ViewMembershipPage() {
+  const t = useTranslations("catalog.memberships");
   const params = useParams();
   const router = useRouter();
   const { token } = useAuth();
@@ -18,7 +20,7 @@ export default function ViewMembershipPage() {
 
   useEffect(() => {
     if (!id) {
-      router.replace("/memberships");
+      router.replace("/catalog/memberships");
       return;
     }
     if (!token) {
@@ -48,14 +50,14 @@ export default function ViewMembershipPage() {
         const status = err?.response?.status ?? err?.status ?? null;
 
         if (status === 404) {
-          router.replace("/memberships");
+          router.replace("/catalog/memberships");
         } else if (status === 401) {
           setError(
-            "Sesión expirada o no autorizada. Intenta ingresar de nuevo.",
+            t("view.error_auth"),
           );
         } else {
-          console.error("Error cargando membresía:", err);
-          setError("No se pudo cargar la información de la membresía.");
+          console.error("Error cargando membresia:", err);
+          setError(t("view.error_load"));
         }
       } finally {
         if (mounted) {
@@ -72,7 +74,7 @@ export default function ViewMembershipPage() {
   }, [id, token, router]);
 
   if (loading) {
-    return <div className="p-6">Cargando Membresías...</div>;
+    return <div className="p-6">{t("view.loading")}</div>;
   }
 
   if (error) {
@@ -82,7 +84,7 @@ export default function ViewMembershipPage() {
   if (!membership) {
     return (
       <div className="p-6 text-gray-500">
-        Membresía no encontrada o no disponible.
+        {t("view.not_found")}
       </div>
     );
   }

--- a/src/app/[locale]/(dashboard)/catalog/memberships/new/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/new/page.tsx
@@ -3,14 +3,15 @@
 import { useState } from "react";
 import type { MembershipType } from "@vitalfit/sdk";
 import type { CreateMembershipType } from "@vitalfit/sdk";
-import { membershipSchema } from "@/lib/validation/membershipSchema";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/PageHeader";
 import MembershipForm from "../MembershipForm";
 import { api } from "@/lib/sdk-config";
-import { Notification } from "@/components/ui/Notification";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
+import { useTranslations } from "next-intl";
+import { createMembershipSchema } from "@/lib/validation/membershipSchema";
+import { toast } from "sonner";
 
 type ValidationResult = {
   success: boolean;
@@ -24,6 +25,7 @@ type MembershipFormData = Omit<MembershipType, "duration_days" | "price"> & {
 };
 
 export default function CreateMembership() {
+  const t = useTranslations("catalog.memberships");
   const router = useRouter();
 
   const [formData, setFormData] = useState<MembershipFormData>({
@@ -39,12 +41,6 @@ export default function CreateMembership() {
     Partial<Record<keyof MembershipType, string>>
   >({});
   const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [showServerError, setShowServerError] = useState({
-    visible: false,
-    message: "",
-  });
-  const [showConnectionError, setShowConnectionError] = useState(false);
 
   const handleChange = (field: keyof MembershipType, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
@@ -53,7 +49,8 @@ export default function CreateMembership() {
 
   const validateMembership = (data: MembershipFormData): ValidationResult => {
     try {
-      // Convertir campos numéricos de string a number para validación
+      const schema = createMembershipSchema((key) => t(`validations.${key.split('.').pop()}`));
+
       const dataToValidate = {
         ...data,
         duration_days:
@@ -61,7 +58,7 @@ export default function CreateMembership() {
         price: data.price === "" ? 0 : Number(data.price),
       };
 
-      const validatedData = membershipSchema.parse(dataToValidate);
+      const validatedData = schema.parse(dataToValidate);
       return {
         success: true,
         data: validatedData,
@@ -90,7 +87,7 @@ export default function CreateMembership() {
         success: false,
         data: null,
         errors: {
-          name: "Error de validación inesperado",
+          name: t("validations.validation_error"),
         },
       };
     }
@@ -98,8 +95,8 @@ export default function CreateMembership() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setShowServerError({ visible: false, message: "" });
-    setShowConnectionError(false);
+
+
 
     const validation = validateMembership(formData);
     if (!validation.success) {
@@ -117,10 +114,7 @@ export default function CreateMembership() {
 
     const token = localStorage.getItem("access_token");
     if (!token || typeof token !== "string" || token.length < 10) {
-      setShowServerError({
-        visible: true,
-        message: "Token de autenticación no encontrado.",
-      });
+      toast.error(t("create.error_auth"));
       return;
     }
 
@@ -135,9 +129,9 @@ export default function CreateMembership() {
     setIsLoading(true);
     try {
       await api.membership.createMembershipType(payload, token);
-      setShowSuccess(true);
+      toast.success(t("create.success"));
       setTimeout(() => {
-        router.push("/memberships");
+        router.push("/catalog/memberships");
       }, 1500);
     } catch (err: unknown) {
       console.error("Error al crear membresía:", err);
@@ -147,15 +141,12 @@ export default function CreateMembership() {
           response?: { data?: { error?: string } };
         };
         if (errorWithResponse.response?.data?.error) {
-          setShowServerError({
-            visible: true,
-            message: errorWithResponse.response.data.error,
-          });
+          toast.error(errorWithResponse.response.data.error);
         } else {
-          setShowConnectionError(true);
+          toast.error(t("create.error_connection_description"));
         }
       } else {
-        setShowConnectionError(true);
+        toast.error(t("create.error_connection_description"));
       }
     } finally {
       setIsLoading(false);
@@ -165,9 +156,9 @@ export default function CreateMembership() {
   return (
     <div className="flex-1 space-y-6 p-8 pt-6 bg-white rounded shadow">
       <form onSubmit={handleSubmit} className="space-y-2">
-        <PageHeader title="CREAR MEMBRESÍA"></PageHeader>
+        <PageHeader title={t("create.title")}></PageHeader>
         <p className="text-sm text-muted-foreground">
-          Agrega la información de la membresía
+          {t("create.subtitle")}
         </p>
 
         <MembershipForm
@@ -182,33 +173,9 @@ export default function CreateMembership() {
           variant="default"
           disabled={isLoading}
         >
-          {isLoading ? "Guardando..." : "Crear"}
+          {isLoading ? t("create.button_saving") : t("create.button_create")}
         </Button>
       </form>
-
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="Membresía creada exitosamente!"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
-      {showConnectionError && (
-        <Notification
-          variant="destructive"
-          title="Error de conexión"
-          description="No se pudo conectar con el servidor. Intenta más tarde."
-          onClose={() => setShowConnectionError(false)}
-        />
-      )}
-      {showServerError.visible && (
-        <Notification
-          variant="destructive"
-          title="Error al crear membresía"
-          description={showServerError.message}
-          onClose={() => setShowServerError({ visible: false, message: "" })}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/memberships/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/page.tsx
@@ -9,8 +9,10 @@ import MembershipTable from "./MembershipTable";
 import { useAuth } from "@/context/AuthContext";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/sdk-config";
+import { useTranslations } from "next-intl";
 
 export default function Membership() {
+  const t = useTranslations("catalog.memberships");
   const router = useRouter();
   const { token } = useAuth();
 
@@ -42,9 +44,8 @@ export default function Membership() {
           search: filters.search || undefined,
         });
 
-        const activeMemberships = result.data?.filter((m) => m.is_active) || [];
-        setMembershipData(activeMemberships);
-        setTotalItems(activeMemberships.length);
+        setMembershipData(result.data || []);
+        setTotalItems(result.total || 0);
       } catch (error) {
         console.error("Error cargando membresías:", error);
         setMembershipData([]);
@@ -61,6 +62,7 @@ export default function Membership() {
 
   const handleFilterChange = (newFilters: { search?: string }) => {
     setFilters((prev) => ({ ...prev, ...newFilters }));
+    setPage(1);
   };
 
   const handleReload = () => {
@@ -69,18 +71,18 @@ export default function Membership() {
 
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
-      <PageHeader title="MEMBRESÍAS">
+      <PageHeader title={t("title")}>
         <Button
           className="bg-transparent text-black border border-gray-100"
-          onClick={() => router.push("/memberships/new")}
+          onClick={() => router.push("/catalog/memberships/new")}
         >
           <PlusIcon className="h-5 w-5" />
-          Agregar una membresía
+          {t("add_button")}
         </Button>
       </PageHeader>
 
       {isLoading ? (
-        <div className="text-center p-10">Cargando Membresías...</div>
+        <div className="text-center p-10">{t("loading")}</div>
       ) : (
         <MembershipTable
           data={membershipData}

--- a/src/components/modules/branches/details/BranchSchedule.tsx
+++ b/src/components/modules/branches/details/BranchSchedule.tsx
@@ -13,22 +13,25 @@ interface BranchScheduleProps {
   onScheduleChange: (updatedSchedule: OperatingHour[]) => void;
   mode: "view" | "edit";
 }
-const dayNameMapping: Record<string, string> = {
-  Monday: "Lunes",
-  Tuesday: "Martes",
-  Wednesday: "Miércoles",
-  Thursday: "Jueves",
-  Friday: "Viernes",
-  Saturday: "Sábado",
-  Sunday: "Domingo",
-};
+import { useTranslations } from "next-intl";
 
 export default function BranchSchedule({
   schedule,
   onScheduleChange,
   mode,
 }: BranchScheduleProps) {
+  const t = useTranslations("branches");
   const isDisabled = mode === "view";
+
+  const dayNameMapping: Record<string, string> = {
+    Monday: t("create.form.admin.days.monday"),
+    Tuesday: t("create.form.admin.days.tuesday"),
+    Wednesday: t("create.form.admin.days.wednesday"),
+    Thursday: t("create.form.admin.days.thursday"),
+    Friday: t("create.form.admin.days.friday"),
+    Saturday: t("create.form.admin.days.saturday"),
+    Sunday: t("create.form.admin.days.sunday"),
+  };
 
   const handleTimeChange = (
     day_of_week: string,
@@ -54,12 +57,12 @@ export default function BranchSchedule({
 
   const columns: Column<OperatingHour>[] = [
     {
-      header: "Día",
+      header: t("create.form.admin.table.day"),
       accessor: "day_of_week", // <-- snake_case
       render: (value) => dayNameMapping[value as string],
     },
     {
-      header: "Apertura",
+      header: t("create.form.admin.table.opening"),
       accessor: "open_time",
       render: (value, row) => (
         <div className="relative w-36">
@@ -77,7 +80,7 @@ export default function BranchSchedule({
       ),
     },
     {
-      header: "Cierre",
+      header: t("create.form.admin.table.closing"),
       accessor: "close_time",
       render: (value, row) => (
         <div className="relative w-36">
@@ -95,7 +98,7 @@ export default function BranchSchedule({
       ),
     },
     {
-      header: "Cerrado",
+      header: t("create.form.admin.table.closed"),
       accessor: "is_closed",
       render: (value, row) => (
         <div className="flex justify-center">

--- a/src/lib/validation/membershipSchema.ts
+++ b/src/lib/validation/membershipSchema.ts
@@ -1,58 +1,84 @@
 import { z } from "zod";
 
-export const membershipSchema = z.object({
-  name: z
-    .string()
-    .min(1, "El nombre es requerido")
-    .max(100, "El nombre no puede tener más de 100 caracteres"),
+export const createMembershipSchema = (t: (key: string) => string) =>
+  z.object({
+    name: z
+      .string()
+      .min(1, t("catalog.memberships.validations.name_required"))
+      .max(100, t("catalog.memberships.validations.name_max")),
 
-  description: z
-    .string()
-    .min(1, "La descripción es requerida")
-    .max(500, "La descripción no puede tener más de 500 caracteres"),
+    description: z
+      .string()
+      .min(1, t("catalog.memberships.validations.description_required"))
+      .max(500, t("catalog.memberships.validations.description_max")),
 
-  duration_days: z
-    .union([z.string(), z.number()])
-    .transform((val) => {
-      if (val === "" || val === null || val === undefined) {
-        return 0;
-      }
-      const num = Number(val);
-      return isNaN(num) ? 0 : Math.max(0, num);
-    })
-    .pipe(
-      z
-        .number()
-        .int("La duración debe ser un número entero")
-        .min(1, "La duración no puede ser cero (0) o negativa")
-        .max(3650, "La duración máxima es 3650 días (10 años)"),
-    ),
+    duration_days: z
+      .union([z.string(), z.number()])
+      .transform((val) => {
+        if (val === "" || val === null || val === undefined) {
+          return 0;
+        }
+        const num = Number(val);
+        return isNaN(num) ? 0 : Math.max(0, num);
+      })
+      .pipe(
+        z
+          .number()
+          .int(t("catalog.memberships.validations.duration_int"))
+          .min(1, t("catalog.memberships.validations.duration_min"))
+          .max(3650, t("catalog.memberships.validations.duration_max")),
+      ),
 
-  price: z
-    .union([z.string(), z.number()])
-    .transform((val) => {
-      if (val === "" || val === null || val === undefined) {
-        return 0;
-      }
-      const num = Number(val);
-      return isNaN(num) ? 0 : num;
-    })
-    .pipe(
-      z
-        .number()
-        .min(1, "El precio no puede cero (0) o negativo")
-        .max(999999.99, "El precio máximo es 999,999.99"),
-    ),
+    price: z
+      .union([z.string(), z.number()])
+      .transform((val) => {
+        if (val === "" || val === null || val === undefined) {
+          return 0;
+        }
+        const num = Number(val);
+        return isNaN(num) ? 0 : num;
+      })
+      .pipe(
+        z
+          .number()
+          .min(1, t("catalog.memberships.validations.price_min"))
+          .max(999999.99, t("catalog.memberships.validations.price_max")),
+      ),
 
-  is_active: z
-    .union([z.boolean(), z.string()])
-    .transform((val) => {
-      if (typeof val === "string") {
-        return val === "active" || val === "true";
-      }
-      return Boolean(val);
-    })
-    .pipe(z.boolean()),
+    is_active: z
+      .union([z.boolean(), z.string()])
+      .transform((val) => {
+        if (typeof val === "string") {
+          return val === "active" || val === "true";
+        }
+        return Boolean(val);
+      })
+      .pipe(z.boolean()),
+  });
+
+// Export legacy schema for backward compatibility
+export const membershipSchema = createMembershipSchema((key) => {
+  // Legacy Spanish translations
+  const translations: Record<string, string> = {
+    "catalog.memberships.validations.name_required": "El nombre es requerido",
+    "catalog.memberships.validations.name_max":
+      "El nombre no puede tener más de 100 caracteres",
+    "catalog.memberships.validations.description_required":
+      "La descripción es requerida",
+    "catalog.memberships.validations.description_max":
+      "La descripción no puede tener más de 500 caracteres",
+    "catalog.memberships.validations.duration_int":
+      "La duración debe ser un número entero",
+    "catalog.memberships.validations.duration_min":
+      "La duración no puede ser cero (0) o negativa",
+    "catalog.memberships.validations.duration_max":
+      "La duración máxima es 3650 días (10 años)",
+    "catalog.memberships.validations.price_min":
+      "El precio no puede cero (0) o negativo",
+    "catalog.memberships.validations.price_max":
+      "El precio máximo es 999,999.99",
+  };
+  return translations[key] || key;
 });
 
 export type MembershipFormData = z.infer<typeof membershipSchema>;


### PR DESCRIPTION
Título del PR
chore(i18n): agregar soporte de idioma en 'Sucursal' y 'Membresía'

Descripción
Este pull request introduce soporte de idioma en los módulos de Sucursal y Membresía, mostrando sus nombres en inglés como Branch y Membership.
El cambio se realizó dentro del flujo de internacionalización (i18n), asegurando consistencia y claridad en la interfaz para equipos bilingües y usuarios internacionales.

Problema Relacionado
El sistema anterior mostraba los nombres únicamente en español, lo que limitaba la accesibilidad y la adaptabilidad del dashboard para usuarios que requieren la interfaz en inglés.

Motivación y Contexto
La actualización responde a la necesidad de:

Mejorar la experiencia del usuario mediante soporte multilenguaje.

Alinear la interfaz con estándares internacionales de nomenclatura.

Facilitar la colaboración en equipos bilingües y la escalabilidad del sistema en contextos globales.

¿Cómo se ha probado?
Se verificó la correcta renderización de los nombres en inglés dentro de los módulos de Sucursal y Membresía.

Se probó la integración con el sistema de internacionalización (i18n).

Se validó que no existieran conflictos con dependencias existentes ni errores en la compilación (npm run build).