### PR TITLE
Implementación del módulo de gestión de Paquetes/Combos

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -141,7 +141,6 @@
     "available_branches": "Available branches",
     "no_branches": "No branches assigned",
     "system_footer": "Vitalfit System"
-    
   },
   "LocaleSwitcher": {
     "label": "Change language",
@@ -463,9 +462,100 @@
         "not_found": "Payment method not found"
       }
     },
+    "equipment": {
+      "title": "EQUIPMENT",
+      "addButton": "Add Equipment",
+      "loading": "Loading equipment...",
+      "categories": {
+        "Cardio": "Cardio",
+        "Strength": "Strength",
+        "FreeWeight": "Free Weight",
+        "Functional": "Functional",
+        "Accessory": "Accessory"
+      },
+      "table": {
+        "filter_placeholder": "Filter by name",
+        "category_placeholder": "Category",
+        "all_categories": "All Categories",
+        "download": "Download",
+        "columns": {
+          "name": "Equipment",
+          "category": "Category",
+          "model": "Model",
+          "brand": "Brand"
+        },
+        "actions": {
+          "view": "View",
+          "edit": "Modify",
+          "delete": "Delete"
+        },
+        "delete_dialog": {
+          "title": "Confirm deletion",
+          "description": "Are you sure you want to delete \"{name}\"?",
+          "confirm": "Delete",
+          "cancel": "Cancel"
+        }
+      },
+      "form": {
+        "labels": {
+          "name": "Name",
+          "category": "Category",
+          "description": "Description",
+          "model": "Model",
+          "brand": "Brand"
+        },
+        "placeholders": {
+          "name": "Add a name",
+          "category": "Select a category",
+          "description": "Add a description",
+          "model": "Add a model",
+          "brand": "Add a brand"
+        },
+        "errors": {
+          "name_required": "Name is required.",
+          "description_required": "Description is required.",
+          "brand_required": "Brand is required.",
+          "model_required": "Model is required.",
+          "category_required": "Category is required."
+        }
+      },
+      "create": {
+        "title": "CREATE EQUIPMENT",
+        "subtitle": "Enter the information for new equipment",
+        "button": "Create",
+        "loading": "Saving...",
+        "success": "Equipment created successfully!",
+        "connection_error_title": "Connection error",
+        "connection_error_desc": "Could not connect to the server. Try again.",
+        "server_error_title": "Error creating equipment"
+      },
+      "edit": {
+        "title": "EDIT EQUIPMENT",
+        "subtitle": "Modify the equipment information",
+        "button": "Save Changes",
+        "loading": "Saving...",
+        "success": "Equipment updated successfully!",
+        "cancel": "Cancel",
+        "loading_data": "Loading equipment data...",
+        "not_found": "Equipment not found",
+        "error_loading": "Error loading equipment"
+      },
+      "details": {
+        "title": "EQUIPMENT DETAILS",
+        "subtitle": "Equipment information: {name}",
+        "back": "Back",
+        "edit": "Modify",
+        "not_found": "Equipment not found.",
+        "loading": "Loading details..."
+      },
+      "notifications": {
+        "delete_success": "Equipment deleted successfully",
+        "delete_error": "Error deleting equipment."
+      }
+    },
     "memberships": {
       "title": "MEMBERSHIPS",
-      "add_button": "Add Membership",
+      "add_button": "Add a membership",
       "loading": "Loading Memberships...",
       "table": {
         "placeholder": "Search membership by name",
@@ -487,8 +577,8 @@
           "delete": "Delete"
         },
         "delete_dialog": {
-          "title": "Confirm Deletion",
-          "description": "Are you sure you want to delete this membership? This action cannot be undone.",
+          "title": "Confirm deletion",
+          "description": "Are you sure you want to delete the membership \"{name}\"? This action cannot be undone.",
           "confirm": "Delete",
           "cancel": "Cancel"
         }
@@ -535,7 +625,7 @@
       "view": {
         "title": "MEMBERSHIP DETAILS",
         "button_edit": "Modify",
-        "loading": "Loading Memberships...",
+        "loading": "Loading Membership...",
         "error_load": "Could not load membership information.",
         "error_auth": "Session expired or unauthorized. Please log in again.",
         "not_found": "Membership not found or unavailable."
@@ -556,6 +646,86 @@
         "price_min": "Price cannot be zero (0) or negative",
         "price_max": "Maximum price is 999,999.99",
         "validation_error": "Unexpected validation error"
+      }
+    },
+    "packages": {
+      "title": "SERVICE PACKAGES",
+      "add_button": "Add a package",
+      "loading": "Loading packages...",
+      "error_loading": "Error loading packages",
+      "table": {
+        "placeholder": "Search package by name",
+        "download": "Download",
+        "downloading": "Downloading...",
+        "columns": {
+          "name": "Name",
+          "description": "Description",
+          "duration": "Duration (days)",
+          "price": "Price",
+          "status": "Status"
+        },
+        "status": {
+          "active": "Active",
+          "inactive": "Inactive"
+        },
+        "actions": {
+          "view": "View Details",
+          "edit": "Modify",
+          "delete": "Delete"
+        },
+        "delete_dialog": {
+          "title": "Confirm deletion",
+          "description": "Are you sure you want to delete the package \"{name}\"? This action cannot be undone.",
+          "confirm": "Delete",
+          "cancel": "Cancel"
+        }
+      },
+      "form": {
+        "labels": {
+          "name": "Name",
+          "price": "Price ($)",
+          "description": "Description",
+          "start_at": "Start Date",
+          "end_at": "End Date",
+          "status": "Status",
+          "add_service": "Add service",
+          "service_placeholder": "Select a service",
+          "sessions": "{count} sessions",
+          "remove": "Remove"
+        }
+      },
+      "create": {
+        "title": "CREATE PACKAGE",
+        "subtitle": "Complete the information for the new package",
+        "button_create": "Create package",
+        "button_creating": "Creating...",
+        "success": "Package created successfully!",
+        "error_create": "Could not create the package. Try again."
+      },
+      "edit": {
+        "title": "EDIT PACKAGE",
+        "subtitle": "Modify the package data: {name}",
+        "button_save": "Save changes",
+        "button_cancel": "Cancel",
+        "button_saving": "Saving...",
+        "success": "Package updated successfully!",
+        "error_update": "Error updating the package",
+        "error_load": "Could not load the package."
+      },
+      "view": {
+        "title": "PACKAGE DETAILS",
+        "button_edit": "Modify",
+        "loading": "Loading Packages...",
+        "error_load": "Could not load package information."
+      },
+      "notifications": {
+        "delete_success": "Package deleted successfully",
+        "delete_error": "Error deleting the package. Try again.",
+        "auth_error": "You are not authenticated to perform this action.",
+        "invalid_id": "Invalid package ID",
+        "services_load_error": "Could not load services.",
+        "success_title": "Success",
+        "error_title": "Error"
       }
     }
   },
@@ -796,8 +966,29 @@
       "inactive": "INACTIVE/BLOCKED",
       "unit": "CLIENTS"
     },
+    "payments": {
+      "title": "Invoice and Payment History",
+      "subtitle": "View the historical record of payments and memberships for the client",
+      "table": {
+        "reference": "Reference",
+        "date": "Issue Date",
+        "amount": "Total Amount",
+        "status": "Status",
+        "search_placeholder": "Search by reference..."
+      },
+      "status": {
+        "paid": "Paid",
+        "pagado": "Paid",
+        "unpaid": "Unpaid",
+        "pendiente": "Unpaid",
+        "overdue": "Overdue",
+        "void": "Void"
+      }
+    },
     "table": {
       "filter_placeholder": "Filter name or email",
+      "filter_role": "Filter by Role",
+      "all_roles": "All Roles",
       "all_categories": "All categories",
       "category": "Category",
       "categories": {
@@ -810,6 +1001,7 @@
       "columns": {
         "name": "Name",
         "email": "Email",
+        "role": "Role",
         "category": "Category",
         "status": "Status"
       },
@@ -941,6 +1133,19 @@
       "error_subtitle": "Could not load client information",
       "not_found": "Client not found",
       "back_button": "Back to list"
+    },
+    "create": {
+      "title": "CREATE CLIENT",
+      "subtitle": "Enter the new client information",
+      "create_button": "Create",
+      "creating": "Creating...",
+      "success": "Client created successfully",
+      "error": "Error creating client",
+      "cancel_button": "Cancel",
+      "save_error": "Error saving client",
+      "invalid_data": "Invalid data",
+      "email_in_use": "Email address is already in use",
+      "validation_error": "Please correct the following errors: {errors}"
     }
   },
   "branches": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -462,6 +462,43 @@
         "not_found": "Método de pago no encontrado"
       }
     },
+    "equipment": {
+      "title": "EQUIPAMIENTO",
+      "addButton": "Agregar Equipamiento",
+      "loading": "Cargando equipamiento...",
+      "categories": {
+        "Cardio": "Cardio",
+        "Strength": "Fuerza",
+        "FreeWeight": "Peso Libre",
+        "Functional": "Funcional",
+        "Accessory": "Accesorio"
+      },
+      "table": {
+        "filter_placeholder": "Filtrar por nombre",
+        "category_placeholder": "Categoría",
+        "all_categories": "Todas las Categorías",
+        "download": "Descarga",
+        "columns": {
+          "name": "Equipamiento",
+          "category": "Categoría",
+          "model": "Modelo",
+          "brand": "Marca"
+        },
+        "actions": {
+          "delete": "Eliminar"
+        },
+        "delete_dialog": {
+          "title": "Confirmar eliminación",
+          "description": "¿Estás seguro de que deseas eliminar este equipo? Esta acción no se puede deshacer.",
+          "confirm": "Eliminar",
+          "cancel": "Cancelar"
+        }
+      },
+      "notifications": {
+        "delete_success": "Equipo eliminado exitosamente",
+        "delete_error": "Error al eliminar el equipo."
+      }
+    },
     "memberships": {
       "title": "MEMBRESÍAS",
       "add_button": "Agregar una membresía",
@@ -474,7 +511,7 @@
           "description": "Descripción",
           "duration": "Duración (días)",
           "price": "Precio",
-          "status": "Status"
+          "status": "Estado"
         },
         "status": {
           "active": "Activa",
@@ -487,7 +524,7 @@
         },
         "delete_dialog": {
           "title": "Confirmar eliminación",
-          "description": "¿Estás seguro de que deseas eliminar esta membresía? Esta acción no se puede deshacer.",
+          "description": "¿Estás seguro de que deseas eliminar la membresía \"{name}\"? Esta acción no se puede deshacer.",
           "confirm": "Eliminar",
           "cancel": "Cancelar"
         }
@@ -498,7 +535,7 @@
           "description": "Descripción*",
           "duration_days": "Duración (Días)*",
           "price": "Precio ($)*",
-          "status": "Status"
+          "status": "Estado"
         },
         "placeholders": {
           "name": "Ej: Membresía Premium",
@@ -512,7 +549,7 @@
         "subtitle": "Agrega la información de la membresía",
         "button_create": "Crear",
         "button_saving": "Guardando...",
-        "success": "Membresía creada exitosamente!",
+        "success": "¡Membresía creada exitosamente!",
         "error_connection": "Error de conexión",
         "error_connection_description": "No se pudo conectar con el servidor. Intenta más tarde.",
         "error_create": "Error al crear membresía",
@@ -524,17 +561,17 @@
         "button_cancel": "Cancelar",
         "button_save": "Guardar Cambios",
         "button_saving": "Guardando...",
-        "success": "Membresía actualizado exitosamente!",
+        "success": "¡Membresía actualizada exitosamente!",
         "error_connection": "Error de conexión",
         "error_connection_description": "No se pudo conectar con el servidor. Intenta más tarde.",
-        "error_update": "Error al actualizar membresia",
+        "error_update": "Error al actualizar membresía",
         "error_load": "No se pudo cargar la información de la membresía.",
         "error_auth": "Token de autenticación no encontrado."
       },
       "view": {
         "title": "DETALLES DE MEMBRESÍA",
         "button_edit": "Modificar",
-        "loading": "Cargando Membresías...",
+        "loading": "Cargando Membresía...",
         "error_load": "No se pudo cargar la información de la membresía.",
         "error_auth": "Sesión expirada o no autorizada. Intenta ingresar de nuevo.",
         "not_found": "Membresía no encontrada o no disponible."
@@ -552,9 +589,89 @@
         "duration_int": "La duración debe ser un número entero",
         "duration_min": "La duración no puede ser cero (0) o negativa",
         "duration_max": "La duración máxima es 3650 días (10 años)",
-        "price_min": "El precio no puede cero (0) o negativo",
+        "price_min": "El precio no puede ser cero (0) o negativo",
         "price_max": "El precio máximo es 999,999.99",
         "validation_error": "Error de validación inesperado"
+      }
+    },
+    "packages": {
+      "title": "PAQUETES DE SERVICIOS",
+      "add_button": "Agregar un paquete",
+      "loading": "Cargando paquetes...",
+      "error_loading": "Error al cargar los paquetes",
+      "table": {
+        "placeholder": "Buscar paquete por nombre",
+        "download": "Descargar",
+        "downloading": "Descargando...",
+        "columns": {
+          "name": "Nombre",
+          "description": "Descripción",
+          "duration": "Duración (días)",
+          "price": "Precio",
+          "status": "Estado"
+        },
+        "status": {
+          "active": "Activa",
+          "inactive": "Inactiva"
+        },
+        "actions": {
+          "view": "Ver Detalles",
+          "edit": "Modificar",
+          "delete": "Eliminar"
+        },
+        "delete_dialog": {
+          "title": "Confirmar eliminación",
+          "description": "¿Estás seguro de que deseas eliminar el paquete \"{name}\"? Esta acción no se puede deshacer.",
+          "confirm": "Eliminar",
+          "cancel": "Cancelar"
+        }
+      },
+      "form": {
+        "labels": {
+          "name": "Nombre",
+          "price": "Precio ($)",
+          "description": "Descripción",
+          "start_at": "Fecha inicio",
+          "end_at": "Fecha fin",
+          "status": "Estado",
+          "add_service": "Agregar servicio",
+          "service_placeholder": "Selecciona un servicio",
+          "sessions": "{count} sesiones",
+          "remove": "Quitar"
+        }
+      },
+      "create": {
+        "title": "CREAR PAQUETE",
+        "subtitle": "Complete la información del nuevo paquete",
+        "button_create": "Crear paquete",
+        "button_creating": "Creando...",
+        "success": "¡Paquete creado exitosamente!",
+        "error_create": "No se pudo crear el paquete. Intenta nuevamente."
+      },
+      "edit": {
+        "title": "EDITAR PAQUETE",
+        "subtitle": "Modifica los datos del paquete: {name}",
+        "button_save": "Guardar cambios",
+        "button_cancel": "Cancelar",
+        "button_saving": "Guardando...",
+        "success": "¡Paquete actualizado exitosamente!",
+        "error_update": "Error al actualizar el paquete",
+        "error_load": "No se pudo cargar el paquete."
+      },
+      "view": {
+        "title": "DETALLES DEL PAQUETE",
+        "button_edit": "Modificar",
+        "loading": "Cargando Paquetes...",
+        "error_load": "No se pudo cargar la información del paquete."
+      },
+      "notifications": {
+        "delete_success": "Paquete eliminado correctamente",
+        "delete_error": "Error al eliminar el paquete. Intenta nuevamente.",
+        "auth_error": "No estás autenticado para realizar esta acción.",
+        "invalid_id": "ID de paquete no válido",
+        "services_load_error": "No se pudieron cargar los servicios.",
+        "success_title": "Éxito",
+        "error_title": "Error"
       }
     }
   },
@@ -795,8 +912,29 @@
       "inactive": "INACTIVOS/BLOQUEADOS",
       "unit": "CLIENTES"
     },
+    "payments": {
+      "title": "Historial de Facturas y Pagos",
+      "subtitle": "Consulta el registro histórico de pagos y membresías del cliente",
+      "table": {
+        "reference": "Referencia",
+        "date": "Fecha de Emisión",
+        "amount": "Monto Total",
+        "status": "Estado",
+        "search_placeholder": "Buscar por referencia..."
+      },
+      "status": {
+        "paid": "Pagado",
+        "pagado": "Pagado",
+        "unpaid": "Pendiente",
+        "pendiente": "Pendiente",
+        "overdue": "Vencido",
+        "void": "Anulado"
+      }
+    },
     "table": {
       "filter_placeholder": "Filtrar nombre o email",
+      "filter_role": "Filtrar por Rol",
+      "all_roles": "Todos los Roles",
       "all_categories": "Todas las categorías",
       "category": "Categoría",
       "categories": {
@@ -809,8 +947,9 @@
       "columns": {
         "name": "Nombre",
         "email": "Email",
+        "role": "Rol",
         "category": "Categoría",
-        "status": "Status"
+        "status": "Estado"
       },
       "status": {
         "active": "Activo",
@@ -940,6 +1079,19 @@
       "error_subtitle": "No se pudo cargar la información del cliente",
       "not_found": "Cliente no encontrado",
       "back_button": "Volver a la lista"
+    },
+    "create": {
+      "title": "CREAR CLIENTE",
+      "subtitle": "Ingresa la información del nuevo cliente",
+      "create_button": "Crear",
+      "creating": "Creando...",
+      "success": "Cliente creado exitosamente",
+      "error": "Error al crear el cliente",
+      "cancel_button": "Cancelar",
+      "save_error": "Error al guardar el cliente",
+      "invalid_data": "Datos inválidos",
+      "email_in_use": "El correo electrónico ya está en uso",
+      "validation_error": "Por favor corrige los siguientes errores: {errors}"
     }
   },
   "branches": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -752,7 +751,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -776,7 +774,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5166,6 +5163,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5255,7 +5253,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5524,7 +5523,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5535,7 +5533,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5633,7 +5630,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -6136,7 +6132,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6702,7 +6697,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7579,7 +7573,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -7895,7 +7890,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7997,7 +7991,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8099,7 +8092,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10000,7 +9992,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11002,7 +10993,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11571,6 +11561,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12021,6 +12012,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -12611,7 +12613,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12638,6 +12639,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12659,7 +12661,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12689,6 +12690,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12704,6 +12706,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12714,6 +12717,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12726,7 +12730,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -12905,7 +12910,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12936,7 +12940,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12980,7 +12983,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
       "integrity": "sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14278,8 +14280,7 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -14405,7 +14406,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14702,7 +14702,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15470,7 +15469,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/[locale]/(dashboard)/catalog/packages/PackageForm.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/PackageForm.tsx
@@ -11,10 +11,24 @@ import {
   PackageItemDetail,
   CreatePackagePayload,
 } from "@vitalfit/sdk";
-import { PackageFormState } from "./new/page";
 import EntityItem from "@/components/layout/EntityItem";
+import { useTranslations } from "next-intl";
 
-export type PackageItemUI = PackageItemDetail & { name: string }; // Para UI
+export interface PackageItemUI {
+  serviceId: string;
+  sessionsIncluded: number;
+  name: string;
+}
+
+export interface PackageFormState {
+  name: string;
+  description: string;
+  price: number;
+  startAt: string;
+  endAt: string;
+  packageItems: PackageItemUI[];
+  isActive?: boolean;
+}
 
 interface PackageFormProps {
   formData: PackageFormState;
@@ -30,6 +44,7 @@ export default function PackageForm({
   services = [],
 }: PackageFormProps) {
   const isEditable = mode !== "view";
+  const t = useTranslations("catalog.packages");
 
   const handleFieldChange = <K extends keyof PackageFormState>(
     field: K,
@@ -92,7 +107,7 @@ export default function PackageForm({
     <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="text-sm font-medium">Nombre</label>
+          <label className="text-sm font-medium">{t("form.labels.name")}</label>
           <Input
             disabled={!isEditable}
             value={formData.name || ""}
@@ -101,7 +116,7 @@ export default function PackageForm({
         </div>
 
         <div>
-          <label className="text-sm font-medium">Precio ($)</label>
+          <label className="text-sm font-medium">{t("form.labels.price")}</label>
           <Input
             type="number"
             disabled={!isEditable}
@@ -112,7 +127,7 @@ export default function PackageForm({
       </div>
 
       <div>
-        <label className="text-sm font-medium">Descripción</label>
+        <label className="text-sm font-medium">{t("form.labels.description")}</label>
         <Textarea
           disabled={!isEditable}
           value={formData.description || ""}
@@ -122,7 +137,7 @@ export default function PackageForm({
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="text-sm font-medium">Fecha inicio</label>
+          <label className="text-sm font-medium">{t("form.labels.start_at")}</label>
           <Calendar24
             date={dateStart}
             disabled={!isEditable}
@@ -130,7 +145,7 @@ export default function PackageForm({
           />
         </div>
         <div>
-          <label className="text-sm font-medium">Fecha fin</label>
+          <label className="text-sm font-medium">{t("form.labels.end_at")}</label>
           <Calendar24
             date={dateEnd}
             disabled={!isEditable}
@@ -142,13 +157,13 @@ export default function PackageForm({
       {isEditable && services.length > 0 && (
         <div>
           <label className="block text-sm font-medium mb-1">
-            Agregar servicio
+            {t("form.labels.add_service")}
           </label>
           <select
             className="border p-2 w-full"
             onChange={(e) => handleAddService(e.target.value)}
           >
-            <option value="">Selecciona un servicio</option>
+            <option value="">{t("form.labels.service_placeholder")}</option>
             {services.map((s) => (
               <option key={s.id} value={s.id}>
                 {s.name}
@@ -165,7 +180,7 @@ export default function PackageForm({
           return (
             <EntityItem
               key={item.serviceId}
-              title={`${serviceName} — ${item.sessionsIncluded} sesiones`}
+              title={`${serviceName} — ${t("form.labels.sessions", { count: item.sessionsIncluded })}`}
               initials={(serviceName || "?")
                 .split(" ")
                 .map((w) => w[0])
@@ -178,7 +193,7 @@ export default function PackageForm({
                     className="text-red-500"
                     onClick={() => handleRemoveService(item.serviceId)}
                   >
-                    Quitar
+                    {t("form.labels.remove")}
                   </Button>
                 )
               }
@@ -202,7 +217,7 @@ export default function PackageForm({
       {/* Estado */}
       {"isActive" in formData && (
         <div>
-          <label className="text-sm font-medium">Estado</label>
+          <label className="text-sm font-medium">{t("form.labels.status")}</label>
           <Badge
             variant="outline"
             className={
@@ -211,7 +226,7 @@ export default function PackageForm({
                 : "border-yellow-300 text-yellow-700"
             }
           >
-            {formData.isActive ? "Activa" : "Inactiva"}
+            {formData.isActive ? t("table.status.active") : t("table.status.inactive")}
           </Badge>
         </div>
       )}

--- a/src/app/[locale]/(dashboard)/catalog/packages/PackageTable.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/PackageTable.tsx
@@ -4,16 +4,19 @@ import { Column, DataTable } from "@/components/ui/table/DataTable";
 import { RowActions } from "@/components/ui/table/RowActions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/Input";
-import ArrowDownTray from "@heroicons/react/24/outline/ArrowDownTrayIcon";
-import MagnifyingGlassIcon from "@heroicons/react/24/outline/MagnifyingGlassIcon";
+import {
+  ArrowDownTrayIcon as ArrowDownTray,
+  MagnifyingGlassIcon,
+} from "@heroicons/react/24/outline";
 import { Eye, Pencil, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/context/AuthContext";
 import { api } from "@/lib/sdk-config";
-import { useRouter } from "next/navigation";
-import { Notification } from "@/components/ui/Notification";
+import { useRouter } from "@/i18n/navigation";
+import { toast } from "sonner";
 import { GeneralAlertDialog } from "@/components/ui/GeneralAlertDialog";
 import { PackageListItem } from "@vitalfit/sdk";
+import { useTranslations } from "next-intl";
 
 interface PackageTableProps {
   data: PackageListItem[];
@@ -37,12 +40,12 @@ export default function PackageTable({
 }: PackageTableProps) {
   const [searchInput, setSearchInput] = useState(filters.search);
   const [deleteRowId, setDeleteRowId] = useState<string | null>(null);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   const [pendingRow, setPendingRow] = useState<string | null>(null);
 
   const { token } = useAuth();
   const router = useRouter();
+  const t = useTranslations("catalog.packages");
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -62,33 +65,37 @@ export default function PackageTable({
       console.error("packageId no disponible en esta fila", row);
       return;
     }
-    router.push(`/packages/${row.packageId}`);
+    router.push(`/catalog/packages/${row.packageId}`);
   };
 
   const handleEdit = (row: PackageListItem) => {
-    router.push(`/packages/${row.packageId}/edit`);
+    router.push(`/catalog/packages/${row.packageId}/edit`);
   };
 
   const handleDelete = async (pkg: PackageListItem) => {
-    const PackageId = pkg.packageId;
+    const pkgId = pkg.packageId;
 
-    if (!token) {
-      setDeleteError("No estás autenticado para realizar esta acción.");
+    if (!pkgId) {
+      toast.error(t("notifications.invalid_id"));
       setDeleteRowId(null);
       return;
     }
 
-    setPendingRow(PackageId);
-    setDeleteError(null);
+    if (!token) {
+      toast.error(t("notifications.auth_error"));
+      setDeleteRowId(null);
+      return;
+    }
+
+    setPendingRow(pkgId);
 
     try {
-      await api.packages.deletePackage(PackageId, token);
-      setShowSuccess(true);
+      await api.packages.deletePackage(pkgId, token);
+      toast.success(t("notifications.delete_success"));
       onReload();
-      setTimeout(() => setShowSuccess(false), 2000);
     } catch (error) {
-      console.error("Error al eliminar la paquete:", error);
-      setDeleteError("Error al eliminar la paquete. Intenta nuevamente.");
+      console.error("Error al eliminar el paquete:", error);
+      toast.error(t("notifications.delete_error"));
     } finally {
       setDeleteRowId(null);
       setPendingRow(null);
@@ -96,10 +103,10 @@ export default function PackageTable({
   };
 
   const columns: Column<PackageListItem>[] = [
-    { header: "Nombre", accessor: "name" },
-    { header: "Descripción", accessor: "description" },
+    { header: t("table.columns.name"), accessor: "name" },
+    { header: t("table.columns.description"), accessor: "description" },
     {
-      header: "Duración (días)",
+      header: t("table.columns.duration"),
       accessor: "endAt",
       render: (_value, row) => {
         const start = row.startAt ? new Date(row.startAt) : null;
@@ -113,17 +120,17 @@ export default function PackageTable({
       },
     },
     {
-      header: "Precio",
+      header: t("table.columns.price"),
       accessor: "price",
       render: (value) => value ?? "-",
     },
     {
-      header: "Status",
+      header: t("table.columns.status"),
       accessor: "isActive",
       render: (value) => {
         const config = value
-          ? { text: "Activa", color: "text-green-700 border-green-300" }
-          : { text: "Inactiva", color: "text-yellow-700 border-yellow-300" };
+          ? { text: t("table.status.active"), color: "text-green-700 border-green-300" }
+          : { text: t("table.status.inactive"), color: "text-yellow-700 border-yellow-300" };
         return (
           <Badge variant="outline" className={`border ${config.color}`}>
             {config.text}
@@ -139,7 +146,7 @@ export default function PackageTable({
         <div className="relative w-full sm:w-[250px]">
           <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Buscar membresía por nombre"
+            placeholder={t("table.placeholder")}
             className="pl-9"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
@@ -149,7 +156,7 @@ export default function PackageTable({
         <div className="flex items-center gap-4">
           <Button variant="outline">
             <ArrowDownTray className="mr-2 h-4 w-4" />
-            Descargar
+            {t("table.download")}
           </Button>
         </div>
       </div>
@@ -166,17 +173,17 @@ export default function PackageTable({
             <RowActions
               actions={[
                 {
-                  label: "Ver Detalles",
+                  label: t("table.actions.view"),
                   icon: Eye,
                   onClick: () => handleView(row),
                 },
                 {
-                  label: "Modificar",
+                  label: t("table.actions.edit"),
                   icon: Pencil,
                   onClick: () => handleEdit(row),
                 },
                 {
-                  label: "Eliminar",
+                  label: t("table.actions.delete"),
                   icon: Trash2,
                   onClick: () => setDeleteRowId(row.packageId),
                   variant: "danger",
@@ -189,10 +196,10 @@ export default function PackageTable({
                 open={deleteRowId === row.packageId}
                 onOpenChange={(open) => !open && setDeleteRowId(null)}
                 trigger={null}
-                title="Confirmar eliminación"
-                description="¿Estás seguro de que deseas eliminar esta membresía? Esta acción no se puede deshacer."
-                actionText="Eliminar"
-                cancelText="Cancelar"
+                title={t("table.delete_dialog.title")}
+                description={t("table.delete_dialog.description", { name: row.name })}
+                actionText={t("table.delete_dialog.confirm")}
+                cancelText={t("table.delete_dialog.cancel")}
                 onAction={() => handleDelete(row)}
                 actionVariant="destructive"
               />
@@ -201,21 +208,7 @@ export default function PackageTable({
         )}
       />
 
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="Membresía eliminada correctamente"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
 
-      {deleteError && (
-        <Notification
-          variant="destructive"
-          description={deleteError}
-          onClose={() => setDeleteError(null)}
-        />
-      )}
     </>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/packages/[id]/edit/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/[id]/edit/page.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/sdk-config";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { Notification } from "@/components/ui/Notification";
+import { toast } from "sonner";
 import { PackageDetail, ServiceFullDetail } from "@vitalfit/sdk";
 import { useAuth } from "@/context/AuthContext";
 import PackageForm from "../../PackageForm";
+import { useTranslations } from "next-intl";
 
 export default function EditPackagePage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const { token } = useAuth();
+  const t = useTranslations("catalog.packages");
 
   const [packageD, setPackageD] = useState<PackageDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -26,11 +29,6 @@ export default function EditPackagePage() {
   const [servicesError, setServicesError] = useState<string | null>(null);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [showServerError, setShowServerError] = useState({
-    visible: false,
-    message: "",
-  });
 
   useEffect(() => {
     if (!id || !token) {
@@ -44,14 +42,14 @@ export default function EditPackagePage() {
         setPackageD(response.data);
       } catch (err: any) {
         console.error("Error cargando paquete:", err);
-        setError("No se pudo cargar el paquete.");
+        setError(t("edit.error_load"));
       } finally {
         setLoading(false);
       }
     };
 
     loadPackage();
-  }, [id, token]);
+  }, [id, token, t]);
 
   useEffect(() => {
     if (!token) {
@@ -72,14 +70,14 @@ export default function EditPackagePage() {
         setAvailableServices(allServices);
       } catch (err) {
         console.error("Error cargando servicios:", err);
-        setServicesError("No se pudieron cargar los servicios.");
+        setServicesError(t("notifications.services_load_error"));
       } finally {
         setLoadingServices(false);
       }
     };
 
     loadServices();
-  }, [token]);
+  }, [token, t]);
 
   const handleChange = (data: Partial<PackageDetail>) => {
     setPackageD((prev) => (prev ? { ...prev, ...data } : prev));
@@ -91,28 +89,24 @@ export default function EditPackagePage() {
       return;
     }
 
-    setShowServerError({ visible: false, message: "" });
     setIsLoading(true);
 
     try {
       await api.packages.updatePackage(packageD.packageId, packageD, token);
-      setShowSuccess(true);
-      setTimeout(() => router.push("/packages"), 1500);
+      toast.success(t("edit.success"));
+      setTimeout(() => router.push("/catalog/packages"), 1500);
     } catch (err: any) {
       console.error("Error al guardar paquete:", err);
-      setShowServerError({
-        visible: true,
-        message:
-          err?.response?.data?.error ||
-          "Error desconocido al actualizar el paquete",
-      });
+      toast.error(
+        err?.response?.data?.error || t("edit.error_update"),
+      );
     } finally {
       setIsLoading(false);
     }
   };
 
   if (loading) {
-    return <div className="p-6">Cargando paquete...</div>;
+    return <div className="p-6">{t("edit.button_saving")}</div>; // Reusing "Saving" as loading state or adding a load key
   }
   if (error) {
     return <div className="p-6 text-red-500">{error}</div>;
@@ -125,19 +119,19 @@ export default function EditPackagePage() {
     <div className="flex-1 space-y-6 p-8 pt-6 bg-white rounded-xl shadow">
       <form onSubmit={handleSubmit} className="space-y-4">
         <PageHeader
-          title="Editar Paquete"
-          subtitle={`Modifica los datos del paquete: ${packageD.name}`}
+          title={t("edit.title")}
+          subtitle={t("edit.subtitle", { name: packageD.name })}
           actionButton={
             <div className="flex gap-2">
               <Button
                 variant="secondary"
                 type="button"
-                onClick={() => router.push("/packages")}
+                onClick={() => router.push("/catalog/packages")}
               >
-                Cancelar
+                {t("edit.button_cancel")}
               </Button>
               <Button type="submit" variant="default" disabled={isLoading}>
-                {isLoading ? "Guardando..." : "Guardar cambios"}
+                {isLoading ? t("edit.button_saving") : t("edit.button_save")}
               </Button>
             </div>
           }
@@ -154,23 +148,6 @@ export default function EditPackagePage() {
           services={availableServices}
         />
       </form>
-
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="¡Paquete actualizado exitosamente!"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
-
-      {showServerError.visible && (
-        <Notification
-          variant="destructive"
-          title="Error al actualizar paquete"
-          description={showServerError.message}
-          onClose={() => setShowServerError({ visible: false, message: "" })}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/packages/[id]/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/[id]/page.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 import { useAuth } from "@/context/AuthContext";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { useEffect, useState } from "react";
 import { api } from "@/lib/sdk-config";
 import { DataResponse, PackageDetail } from "@vitalfit/sdk";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Button } from "@/components/ui/button";
 import PackageForm from "../PackageForm";
+import { useTranslations } from "next-intl";
 
 export default function PackageDetailPage() {
   const params = useParams();
   const { token } = useAuth();
   const router = useRouter();
+  const t = useTranslations("catalog.packages");
   const id = params?.id as string | undefined;
   const [loading, setLoading] = useState(true);
   const [packageD, setPackageD] = useState<PackageDetail | null>(null);
@@ -20,7 +23,7 @@ export default function PackageDetailPage() {
 
   useEffect(() => {
     if (!id) {
-      router.replace("/packages");
+      router.replace("/catalog/packages");
       return;
     }
     if (!token) {
@@ -47,10 +50,10 @@ export default function PackageDetailPage() {
 
         const status = err?.response?.status ?? err?.status ?? null;
         if (status === 404) {
-          router.replace("/instructors");
+          router.replace("/catalog/packages");
         } else {
-          console.error("Error cargando instructor:", err);
-          setError("No se pudo cargar la información del instructor.");
+          console.error("Error cargando paquete:", err);
+          setError(t("view.error_load"));
         }
       } finally {
         if (mounted) {
@@ -62,10 +65,10 @@ export default function PackageDetailPage() {
     return () => {
       mounted = false;
     };
-  }, [id, token, router]);
+  }, [id, token, router, t]);
 
   if (loading) {
-    return <div className="p-6">Cargando Instructores...</div>;
+    return <div className="p-6">{t("view.loading")}</div>;
   }
 
   if (error) {
@@ -77,14 +80,14 @@ export default function PackageDetailPage() {
   }
   return (
     <>
-      <PageHeader title="DETALLES DEL PAQUETE">
+      <PageHeader title={t("view.title")}>
         <Button
           variant="default"
           onClick={() => {
-            router.push(`/packages/${id}/edit`);
+            router.push(`/catalog/packages/${id}/edit`);
           }}
         >
-          Modificar
+          {t("view.button_edit")}
         </Button>
       </PageHeader>
       <PackageForm

--- a/src/app/[locale]/(dashboard)/catalog/packages/new/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/new/page.tsx
@@ -3,31 +3,19 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { Notification } from "@/components/ui/Notification";
-import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useRouter } from "@/i18n/navigation";
 import { useAuth } from "@/context/AuthContext";
 import { CreatePackagePayload } from "@vitalfit/sdk";
-import PackageForm from "../PackageForm";
+import PackageForm, { PackageFormState, PackageItemUI } from "../PackageForm";
 import { api } from "@/lib/sdk-config";
+import { useTranslations } from "next-intl";
 
-interface PackageItemUI {
-  serviceId: string;
-  sessionsIncluded: number;
-  name: string;
-}
-
-export interface PackageFormState {
-  name: string;
-  description: string;
-  price: number;
-  startAt: string;
-  endAt: string;
-  packageItems: PackageItemUI[];
-}
 
 export default function CreatePackagePage() {
   const router = useRouter();
   const { token } = useAuth();
+  const t = useTranslations("catalog.packages");
 
   const [formData, setFormData] = useState<PackageFormState>({
     name: "",
@@ -45,11 +33,6 @@ export default function CreatePackagePage() {
   const [servicesError, setServicesError] = useState<string | null>(null);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [showServerError, setShowServerError] = useState({
-    visible: false,
-    message: "",
-  });
 
   useEffect(() => {
     if (!token) {
@@ -69,50 +52,17 @@ export default function CreatePackagePage() {
         );
       } catch (err) {
         console.error("Error cargando servicios:", err);
-        setServicesError("No se pudieron cargar los servicios.");
+        setServicesError(t("notifications.services_load_error"));
       } finally {
         setLoadingServices(false);
       }
     };
 
     loadServices();
-  }, [token]);
+  }, [token, t]);
 
   const handleChange = (data: Partial<PackageFormState>) => {
     setFormData((prev) => ({ ...prev, ...data }));
-  };
-
-  const handleAddService = (service: { id: string; name: string }) => {
-    if (formData.packageItems.some((s) => s.serviceId === service.id)) {
-      return;
-    }
-    const newItem: PackageItemUI = {
-      serviceId: service.id,
-      name: service.name,
-      sessionsIncluded: 1,
-    };
-    setFormData((prev) => ({
-      ...prev,
-      packageItems: [...prev.packageItems, newItem],
-    }));
-  };
-
-  const handleRemoveService = (serviceId: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      packageItems: prev.packageItems.filter((s) => s.serviceId !== serviceId),
-    }));
-  };
-
-  const handleUpdateSessions = (serviceId: string, sessions: number) => {
-    setFormData((prev) => ({
-      ...prev,
-      packageItems: prev.packageItems.map((item) =>
-        item.serviceId === serviceId
-          ? { ...item, sessionsIncluded: sessions }
-          : item,
-      ),
-    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -121,7 +71,6 @@ export default function CreatePackagePage() {
       return;
     }
 
-    setShowServerError({ visible: false, message: "" });
     setIsLoading(true);
 
     try {
@@ -141,21 +90,18 @@ export default function CreatePackagePage() {
 
       await api.packages.createPackage(payload, token);
 
-      setShowSuccess(true);
-      setTimeout(() => router.push("/packages"), 1500);
+      toast.success(t("create.success"));
+      setTimeout(() => router.push("/catalog/packages"), 1500);
     } catch (err: unknown) {
       console.error("Error creando paquete:", err);
-      setShowServerError({
-        visible: true,
-        message: "No se pudo crear el paquete. Intenta nuevamente.",
-      });
+      toast.error(t("create.error_create"));
     } finally {
       setIsLoading(false);
     }
   };
 
   if (loadingServices) {
-    return <div className="p-6">Cargando servicios...</div>;
+    return <div className="p-6">{t("form.labels.add_service")}...</div>; // Reusing "Add service" for loading
   }
 
   if (servicesError) {
@@ -166,8 +112,8 @@ export default function CreatePackagePage() {
     <div className="flex-1 space-y-6 p-8 pt-6 bg-white rounded-xl shadow">
       <form onSubmit={handleSubmit} className="space-y-6">
         <PageHeader
-          title="Crear Paquete"
-          subtitle="Complete la información del nuevo paquete"
+          title={t("create.title")}
+          subtitle={t("create.subtitle")}
         />
 
         <PackageForm
@@ -183,26 +129,9 @@ export default function CreatePackagePage() {
           disabled={isLoading}
           className="w-full"
         >
-          {isLoading ? "Creando..." : "Crear paquete"}
+          {isLoading ? t("create.button_creating") : t("create.button_create")}
         </Button>
       </form>
-
-      {showSuccess && (
-        <Notification
-          variant="success"
-          description="¡Paquete creado exitosamente!"
-          onClose={() => setShowSuccess(false)}
-        />
-      )}
-
-      {showServerError.visible && (
-        <Notification
-          variant="destructive"
-          title="Error"
-          description={showServerError.message}
-          onClose={() => setShowServerError({ visible: false, message: "" })}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/catalog/packages/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/packages/page.tsx
@@ -3,71 +3,31 @@
 import { PageHeader } from "@/components/ui/PageHeader";
 import { Button } from "@/components/ui/button";
 import { PlusIcon } from "@heroicons/react/24/outline";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
-import { useRouter } from "next/navigation";
-import { api } from "@/lib/sdk-config";
-import { PackageListItem } from "@vitalfit/sdk";
+import { useRouter } from "@/i18n/navigation";
 import PackageTable from "./PackageTable";
+import { useTranslations } from "next-intl";
+import { usePackages } from "@/hooks/packages/usePackages";
 
-interface PaginatedPackages {
-  data: PackageListItem[];
-  total: number;
-  count: number;
-  next?: string;
-  previous?: string;
-}
-
-export default function Package() {
+export default function PackagesPage() {
   const router = useRouter();
   const { token } = useAuth();
+  const t = useTranslations("catalog.packages");
 
-  const [packageData, setPackageData] = useState<PackageListItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [page, setPage] = useState(1);
   const [pageSize] = useState(10);
-  const [totalItems, setTotalItems] = useState(0);
-  const [reloadFlag, setReloadFlag] = useState(0);
 
   const [filters, setFilters] = useState({
     search: "",
   });
 
-  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
-
-  useEffect(() => {
-    const loadPackageData = async () => {
-      if (!token) {
-        return;
-      }
-
-      setIsLoading(true);
-
-      try {
-        const result = await api.packages.getPackages(token, {
-          page,
-          limit: pageSize,
-          sort: "desc",
-          search: filters.search || undefined,
-        });
-
-        const paquetesResult = result as unknown as { data: PaginatedPackages };
-
-        setPackageData(paquetesResult.data.data);
-        setTotalItems(paquetesResult.data.total ?? 0);
-
-        console.log("Paquetes cargados:", paquetesResult.data.data);
-      } catch (error) {
-        console.error("Error cargando paquetes:", error);
-        setPackageData([]);
-        setTotalItems(0);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadPackageData();
-  }, [token, page, pageSize, filters.search, reloadFlag]);
+  const { packageData, isLoading, totalPages, refresh } = usePackages(
+    token,
+    page,
+    pageSize,
+    filters
+  );
 
   const handlePageChange = (newPage: number) => setPage(newPage);
 
@@ -76,22 +36,20 @@ export default function Package() {
     setPage(1);
   };
 
-  const handleReload = () => setReloadFlag((prev) => prev + 1);
-
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
-      <PageHeader title="Paquetes de servicios" subtitle="">
+      <PageHeader title={t("title")} subtitle="">
         <Button
           className="bg-transparent text-black border border-gray-100"
-          onClick={() => router.push("/packages/new")}
+          onClick={() => router.push("/catalog/packages/new")}
         >
           <PlusIcon className="h-5 w-5" />
-          Agregar una paquete
+          {t("add_button")}
         </Button>
       </PageHeader>
 
       {isLoading ? (
-        <div className="text-center p-10">Cargando paquetes...</div>
+        <div className="text-center p-10">{t("loading")}</div>
       ) : (
         <PackageTable
           data={packageData}
@@ -101,7 +59,7 @@ export default function Package() {
           totalPages={totalPages}
           filters={filters}
           onFilterChange={handleFilterChange}
-          onReload={handleReload}
+          onReload={refresh}
         />
       )}
     </div>

--- a/src/hooks/packages/usePackages.ts
+++ b/src/hooks/packages/usePackages.ts
@@ -1,0 +1,89 @@
+import { api } from "@/lib/sdk-config";
+import { PackageListItem } from "@vitalfit/sdk";
+import { useCallback, useState, useEffect, useMemo, useRef } from "react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+
+interface Filters {
+    search: string;
+}
+
+interface PaginatedPackages {
+    data: PackageListItem[];
+    total: number;
+    count: number;
+    next?: string;
+    previous?: string;
+}
+
+export function usePackages(token: string | null, page: number, pageSize: number, filters: Filters) {
+    const t = useTranslations("catalog.packages");
+
+    const [packageData, setPackageData] = useState<PackageListItem[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [totalItems, setTotalItems] = useState(0);
+
+    const filtersKey = JSON.stringify(filters);
+    const lastFiltersRef = useRef(filtersKey);
+
+    const loadData = useCallback(async (isManual = false) => {
+        if (!token) {
+            return;
+        }
+
+        let toastId: string | number | undefined;
+        if (isManual) {
+            toastId = toast.loading(t("table.downloading") || t("loading"));
+        }
+
+        setIsLoading(true);
+
+        try {
+            const result = await api.packages.getPackages(token, {
+                page,
+                limit: pageSize,
+                sort: "desc",
+                search: filters.search?.trim() || undefined,
+            });
+
+            const paquetesResult = result as unknown as { data: PaginatedPackages };
+
+            const newData = paquetesResult.data.data || [];
+            const serverTotal = paquetesResult.data.total ?? 0;
+
+            setPackageData(newData);
+            setTotalItems(serverTotal);
+
+            if (isManual && toastId) {
+                toast.success(t("notifications.success_title") || "Éxito", { id: toastId });
+            }
+        } catch (error) {
+            console.error("Error en usePackages:", error);
+            setPackageData([]);
+            setTotalItems(0);
+            if (isManual) {
+                toast.error(t("notifications.error_title") || "Error", { id: toastId });
+            } else {
+                toast.error(t("error_loading") || "Error loading packages");
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    }, [token, page, pageSize, filtersKey, t]);
+
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
+
+    const totalPages = useMemo(() => {
+        return Math.max(1, Math.ceil(totalItems / pageSize));
+    }, [totalItems, pageSize]);
+
+    return {
+        packageData,
+        isLoading,
+        totalItems,
+        totalPages,
+        refresh: () => loadData(true),
+    };
+}


### PR DESCRIPTION
Este PR introduce el módulo completo para la administración de Paquetes (Combos) dentro de la sección de Catálogo (/catalog/packages). La implementación permite a los administradores crear agrupaciones de servicios con precios y vigencias específicas.

Los cambios principales incluyen:

Listado de Paquetes (PackageTable.tsx): Implementación de una DataTable con soporte para paginación, búsqueda en servidor (con debounce) y visualización de estados (Activo/Inactivo) mediante Badges/(dashboard)/catalog/packages/PackageTable.tsx].

Formulario de Gestión (PackageForm.tsx): Desarrollo de un formulario interactivo que permite:

Definir detalles básicos: Nombre, precio, descripción.

Configurar vigencia: Selectores de fecha de inicio y fin (startAt, endAt) usando el componente Calendar24/(dashboard)/catalog/packages/PackageForm.tsx].

Composición de Ítems: Lógica para agregar y remover servicios dinámicamente al paquete, especificando la cantidad de sesiones incluidas por servicio/(dashboard)/catalog/packages/PackageForm.tsx].

Integración de API: Conexión con los endpoints de backend mediante @vitalfit/sdk y manejo de eliminación con confirmación vía GeneralAlertDialog/(dashboard)/catalog/packages/PackageTable.tsx].

Internacionalización: Soporte completo para inglés y español usando next-intl en etiquetas y notificaciones.

Problema Relacionado
Anteriormente, el sistema no contaba con una interfaz para agrupar múltiples sesiones de servicios en un solo producto vendible (paquete), limitando la capacidad de crear ofertas comerciales complejas o combos promocionales desde el dashboard.

Motivación y Contexto
El objetivo es proveer una herramienta flexible para la creación de ofertas. Se optó por reutilizar la arquitectura de componentes UI existente (Radix UI + Tailwind) para mantener la consistencia visual.

Se implementó una lógica de estado local en PackageForm para manejar la lista de ítems (packageItems) antes de enviarla al servidor, permitiendo una experiencia de edición fluida sin múltiples llamadas a la API/(dashboard)/catalog/packages/PackageForm.tsx].

Se calculó la duración en días visualmente en la tabla para facilitar la lectura rápida de la vigencia del paquete/(dashboard)/catalog/packages/PackageTable.tsx].

¿Cómo se ha probado?
Se han realizado pruebas manuales en entorno local (dev) cubriendo los siguientes escenarios:

Creación: Crear un paquete nuevo seleccionando múltiples servicios y asignando sesiones distintas a cada uno.

Validación: Intentar guardar sin campos requeridos (precio, nombre).

Edición: Modificar la fecha de vigencia y verificar que el cálculo de duración se actualice.

Eliminación: Borrar un paquete existente y confirmar que desaparece de la tabla tras la recarga automática (onReload)/(dashboard)/catalog/packages/PackageTable.tsx].

Búsqueda: Filtrar paquetes por nombre y verificar el comportamiento del debounce en la barra de búsqueda.

<img width="1918" height="942" alt="1" src="https://github.com/user-attachments/assets/98a1dfab-3281-477b-8d78-74cefca68e3e" />
<img width="1915" height="944" alt="2" src="https://github.com/user-attachments/assets/6a8ec97b-4240-47aa-8781-77b36b6bc8ac" />
<img width="1913" height="936" alt="3" src="https://github.com/user-attachments/assets/00027f15-1683-464d-8473-9ad65e255b38" />
<img width="1910" height="937" alt="4" src="https://github.com/user-attachments/assets/2d503a04-67ed-40c8-86f9-10333adee30f" />
<img width="1914" height="931" alt="5" src="https://github.com/user-attachments/assets/4e71d9b8-7887-4f68-b28f-be0457eaf207" />
