### PR TITLE
Pasar el dato is_active como boleeano

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-table": "^8.21.3",
-        "@vitalfit/sdk": "^0.3.2",
+        "@vitalfit/sdk": "^0.3.3",
         "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -6157,10 +6157,9 @@
       ]
     },
     "node_modules/@vitalfit/sdk": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.3.2.tgz",
-      "integrity": "sha512-O6U9rUrX8OmxaLJoWwh7avG8TnyIO0iO+r36xdqTOn9rz75UvdJLQSn8UK2wXObejkIRQqtTsGRRtWP/YTZjRQ==",
-      "license": "MIT",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@vitalfit/sdk/-/sdk-0.3.3.tgz",
+      "integrity": "sha512-z/4BwVq/W4wb5BFmZOcH0RqubzHV/7Uqnu4fgZ62Y0x9Ofs3lxkxQ70+6i8kmKTBn/WKJRIcr3IDlpUy5lKxlQ==",
       "dependencies": {
         "axios": "^1.12.2"
       }
@@ -12051,6 +12050,16 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
-    "@vitalfit/sdk": "^0.3.2",
+    "@vitalfit/sdk": "^0.3.3",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/[locale]/(dashboard)/catalog/memberships/MembershipForm.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/MembershipForm.tsx
@@ -146,16 +146,18 @@ export default function MembershipForm({
           <Select
             name="is_active"
             onValueChange={(value) => onChange("is_active", value)}
-            value={formData.is_active ? "active" : "inactive"}
+            value={String(formData.is_active)}
           >
             <SelectTrigger className="w-full sm:w-[200px] border border-gray-300 rounded-md px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
               <SelectValue>
-                {formData.is_active ? t("table.status.active") : t("table.status.inactive")}
+                {String(formData.is_active) === "true"
+                  ? t("table.status.active")
+                  : t("table.status.inactive")}
               </SelectValue>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="active">{t("table.status.active")}</SelectItem>
-              <SelectItem value="inactive">{t("table.status.inactive")}</SelectItem>
+              <SelectItem value="true">{t("table.status.active")}</SelectItem>
+              <SelectItem value="false">{t("table.status.inactive")}</SelectItem>
             </SelectContent>
           </Select>
           {errors.is_active && (

--- a/src/app/[locale]/(dashboard)/catalog/memberships/[id]/edit/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/[id]/edit/page.tsx
@@ -98,14 +98,19 @@ export default function EditMembership() {
   }, [membership]);
 
   const handleChange = (field: keyof MembershipType, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
+    let newValue: string | boolean = value;
+    if (field === "is_active") {
+      newValue = value === "true";
+    }
+
+    setFormData((prev) => ({ ...prev, [field]: newValue }));
     setErrors((prev) => ({ ...prev, [field]: undefined }));
   };
 
   const validate = (
     formData: MembershipType,
     setErrors: (errors: Partial<Record<keyof MembershipType, string>>) => void
-  ): boolean => {
+  ) => {
     const schema = createMembershipSchema((key) =>
       t(`validations.${key.split(".").pop()}`)
     );
@@ -125,18 +130,18 @@ export default function EditMembership() {
       );
 
       setErrors(formattedErrors);
-      return false;
+      return null;
     }
 
     setErrors({});
-    return true;
+    return result.data;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const isValid = validate(formData, setErrors);
-    if (!isValid) {
+    const validatedData = validate(formData, setErrors);
+    if (!validatedData) {
       return;
     }
 
@@ -147,11 +152,11 @@ export default function EditMembership() {
     }
 
     const payload: UpdateMembershipType = {
-      name: formData.name,
-      description: formData.description ?? "",
-      duration_days: formData.duration_days,
-      is_active: formData.is_active,
-      price: formData.price,
+      name: validatedData.name,
+      description: validatedData.description,
+      duration_days: validatedData.duration_days,
+      is_active: validatedData.is_active,
+      price: validatedData.price,
     };
 
     setIsLoading(true);

--- a/src/app/[locale]/(dashboard)/catalog/memberships/new/page.tsx
+++ b/src/app/[locale]/(dashboard)/catalog/memberships/new/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import MembershipForm from "../MembershipForm";
 import { api } from "@/lib/sdk-config";
 import { z } from "zod";
+import { useAuth } from "@/context/AuthContext";
 import { useTranslations } from "next-intl";
 import { createMembershipSchema } from "@/lib/validation/membershipSchema";
 import { toast } from "sonner";
@@ -27,6 +28,7 @@ type MembershipFormData = Omit<MembershipType, "duration_days" | "price"> & {
 export default function CreateMembership() {
   const t = useTranslations("catalog.memberships");
   const router = useRouter();
+  const { token } = useAuth();
 
   const [formData, setFormData] = useState<MembershipFormData>({
     membership_type_id: "",
@@ -112,7 +114,6 @@ export default function CreateMembership() {
       return;
     }
 
-    const token = localStorage.getItem("access_token");
     if (!token || typeof token !== "string" || token.length < 10) {
       toast.error(t("create.error_auth"));
       return;

--- a/src/lib/validation/membershipSchema.ts
+++ b/src/lib/validation/membershipSchema.ts
@@ -49,7 +49,7 @@ export const createMembershipSchema = (t: (key: string) => string) =>
       .union([z.boolean(), z.string()])
       .transform((val) => {
         if (typeof val === "string") {
-          return val === "active" || val === "true";
+          return val === "true";
         }
         return Boolean(val);
       })


### PR DESCRIPTION
Título
Corrección del campo  para manejar valores booleanos.

Description (Descripción)
Se modificó la lógica de envío del campo (is_active)  para que ahora se maneje como un valor booleano (true/false).
Anteriormente, el campo se enviaba como un string, lo que ocasionaba que siempre se interpretara como activo, sin importar el valor real. Con esta corrección, el sistema reconoce correctamente el estado del campo.

Motivation and Context (Motivación y Contexto)
Este cambio es necesario para garantizar que el estado de activación de los registros se procese de forma correcta.
El error anterior provocaba que todos los registros se marcaran como activos, generando inconsistencias en la base de datos y en la lógica de negocio.
Con la corrección, se asegura que el sistema refleje fielmente el estado real de cada registro.

How Has This Been Tested? (¿Cómo se ha probado?)
 Se creó un registro con is_active = true y se verificó que se guardara correctamente como activo.
 Se creó un registro con is_active = false y se comprobó que se guardara correctamente como inactivo.
 Se revisaron los endpoints relacionados para confirmar que el valor booleano se interpreta de forma adecuada.
 Se ejecutaron pruebas unitarias y de integración para validar que no se afectaran otros módulos dependientes.

